### PR TITLE
less confusing "show %d link previews".

### DIFF
--- a/src/partials/MediaSet.svelte
+++ b/src/partials/MediaSet.svelte
@@ -33,7 +33,7 @@
     <Media link={annotated[0]} onClose={close} />
     {#if annotated.length > 1}
       <p class="text-gray-500 py-4 text-center underline" on:click={openModal}>
-        <i class="fa fa-plus" /> Show {annotated.length} link previews
+        <i class="fa fa-plus" /> Show all {annotated.length} link previews
       </p>
     {/if}
   </div>


### PR DESCRIPTION
I always read this as "show +2", for example, when there are only two and since I am already seeing one it should be "show +1", but adding the word "all" will probably fix that and make it clear.