### PR TITLE
altered tab name from "messages" to "conversations"

### DIFF
--- a/src/app/views/MessagesList.svelte
+++ b/src/app/views/MessagesList.svelte
@@ -46,7 +46,7 @@
 
 <Content>
   <div class="relative">
-    <Tabs tabs={["messages", "requests"]} {activeTab} setActiveTab={navigate} {getDisplay} />
+    <Tabs tabs={["conversations", "requests"]} {activeTab} setActiveTab={navigate} {getDisplay} />
     <Popover triggerType="mouseenter" class="absolute right-7 top-7 hidden sm:block">
       <div slot="trigger">
         <i


### PR DESCRIPTION
Since the counter next to the tab count number of active conversations rather than unread messages, I think this makes more sense; being more intuitive.