### PR TITLE
Added highlight color when hovering over note action buttons

### DIFF
--- a/src/app/shared/NoteActions.svelte
+++ b/src/app/shared/NoteActions.svelte
@@ -111,7 +111,7 @@
 <div class="flex justify-between text-gray-1" on:click|stopPropagation>
   <div class="flex">
     <button
-      class={cx("w-16 text-left", {
+      class={cx("w-16 text-left hover:text-accent", {
         "pointer-events-none opacity-50": disableActions,
       })}
       on:click={reply.start}>
@@ -119,7 +119,7 @@
       {$repliesCount}
     </button>
     <button
-      class={cx("w-16 text-left", {
+      class={cx("w-16 text-left hover:text-accent", {
         "pointer-events-none opacity-50": disableActions || note.pubkey === Keys.pubkey.get(),
         "text-accent": like,
       })}
@@ -132,7 +132,7 @@
     </button>
     {#if Env.ENABLE_ZAPS}
       <button
-        class={cx("w-20 text-left", {
+        class={cx("w-20 text-left hover:text-accent", {
           "pointer-events-none opacity-50": disableActions || !canZap,
           "text-accent": zap,
         })}


### PR DESCRIPTION
Added tailwind hover class to implement enhancement suggestion:

[Add a highlight color when hovering over note action buttons #133](https://github.com/coracle-social/coracle/issues/133)

Hover class added at the end of string to be consistent with how hover classes are added in the rest of the codebase (ie. in NoteContentKind3.svelte file)
