### PR TITLE
fix nip98 authorization and actually sign the header

### DIFF
--- a/src/engine/media/commands.ts
+++ b/src/engine/media/commands.ts
@@ -14,8 +14,8 @@ export const uploadToNostrBuild = async body => {
   })
 
   const event = await ($signer.canSign()
-    ? $signer.prepAsUser(template)
-    : $signer.prepWithKey(template, generatePrivateKey()))
+    ? $signer.signAsUser(template)
+    : $signer.signWithKey(template, generatePrivateKey()))
 
   return Fetch.fetchJson(url, {
     body,


### PR DESCRIPTION
This will fix the problem with upload to nostr.build not being authenticated as it should.