### PR TITLE
Update SideNav.svelte (Feedback Button Removal)

### DIFF
--- a/src/app/SideNav.svelte
+++ b/src/app/SideNav.svelte
@@ -74,9 +74,6 @@
   <NavItem href="/about">
     <i class="fa fa-info-circle mr-2" /> About
   </NavItem>
-  <NavItem external href="https://github.com/coracle-social/coracle/issues/new">
-    <i class="fa fa-message mr-2" /> Feedback
-  </NavItem>
   <li class="absolute bottom-0 flex w-full justify-center gap-2 p-2 text-sm text-gray-5">
     <Anchor external theme="anchor" href="/public/terms.html">Terms</Anchor>
     &bull;


### PR DESCRIPTION
consider removing Feedback menu NavItem

- the 3 lines are not working and give back "Sorry, we weren't able to find "https:"." 
<img width="451" alt="Schermafbeelding 2023-10-29 om 01 08 18" src="https://github.com/coracle-social/coracle/assets/127629040/105d7c7f-10de-4f36-9d14-59b73efc91b0">


- feedback can already be given under About (Get in touch - Open an issue), so maybe it's redundant? _(unless you wanted to do something else with the Feedback item ofc)_