### PR TITLE
fix response from server

### DIFF
--- a/src/engine/media/commands.ts
+++ b/src/engine/media/commands.ts
@@ -33,7 +33,7 @@ export const uploadFileToHost = async (url, file) => {
     const {status, nip94_event} = await nip98Fetch(response.processing_url, "GET")
 
     if (status === "success") {
-      return Tags.from(nip94_event).type("url").values().first()
+      return nip94_event
     }
 
     if (now() - startTime > 60) {


### PR DESCRIPTION
In some update Coracle stopped using only the url:

Tags.from(nip94_event).type("url").values().first()

To use all tags, that broke compatibility with all NIP96 servers except those that don't use delayed processing.

