### PR TITLE
Format time and date based on browser regional settings

### DIFF
--- a/src/app/shared/EventDate.svelte
+++ b/src/app/shared/EventDate.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import {Tags} from "paravel"
-  import {secondsToDate} from "src/util/misc"
+  import {secondsToDate, getLocale} from "src/util/misc"
 
   export let event
 
   const date = secondsToDate(Tags.from(event).getValue("start"))
-  const monthFmt = new Intl.DateTimeFormat("en-US", {month: "short"})
-  const dayFmt = new Intl.DateTimeFormat("en-US", {day: "numeric"})
+  const monthFmt = new Intl.DateTimeFormat(getLocale(), {month: "short"})
+  const dayFmt = new Intl.DateTimeFormat(getLocale(), {day: "numeric"})
 </script>
 
 <div class="flex flex-col gap-1 px-12">

--- a/src/app/shared/EventInfo.svelte
+++ b/src/app/shared/EventInfo.svelte
@@ -2,7 +2,7 @@
   import cx from "classnames"
   import {Tags} from "paravel"
   import {Naddr} from "src/util/nostr"
-  import {secondsToDate, formatTimestamp, formatTimestampAsDate} from "src/util/misc"
+  import {secondsToDate, formatTimestamp, formatTimestampAsDate, getLocale} from "src/util/misc"
   import Anchor from "src/partials/Anchor.svelte"
   import Chip from "src/partials/Chip.svelte"
   import GroupLink from "src/app/shared/GroupLink.svelte"
@@ -16,8 +16,8 @@
   export let showDate = false
   export let actionsInline = false
 
-  const timeFmt = new Intl.DateTimeFormat("en-US", {timeStyle: "short"})
-  const datetimeFmt = new Intl.DateTimeFormat("en-US", {dateStyle: "short", timeStyle: "short"})
+  const timeFmt = new Intl.DateTimeFormat(getLocale(), {timeStyle: "short"})
+  const datetimeFmt = new Intl.DateTimeFormat(getLocale(), {dateStyle: "short", timeStyle: "short"})
   const groupAddrs = Tags.from(event).circles().all()
   const {name, title, start, end, location} = Tags.from(event).getDict()
   const startDate = secondsToDate(start)

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -22,8 +22,10 @@ export const getTimeZone = () => new Date().toString().match(/GMT[^\s]+/)
 
 export const createLocalDate = (dateString: any) => new Date(`${dateString} ${getTimeZone()}`)
 
+export const getLocale = () => (new Intl.DateTimeFormat()).resolvedOptions().locale
+
 export const formatTimestamp = (ts: number) => {
-  const formatter = new Intl.DateTimeFormat("en-US", {
+  const formatter = new Intl.DateTimeFormat(getLocale(), {
     dateStyle: "short",
     timeStyle: "short",
   })
@@ -32,7 +34,7 @@ export const formatTimestamp = (ts: number) => {
 }
 
 export const formatTimestampAsDate = (ts: number) => {
-  const formatter = new Intl.DateTimeFormat("en-US", {
+  const formatter = new Intl.DateTimeFormat(getLocale(), {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -57,7 +59,8 @@ export const formatTimestampRelative = (ts: number) => {
     delta = Math.round(delta / seconds(1, "day"))
   }
 
-  const formatter = new Intl.RelativeTimeFormat("en-US", {
+  const locale = (new Intl.RelativeTimeFormat()).resolvedOptions().locale
+  const formatter = new Intl.RelativeTimeFormat(locale, {
     numeric: "auto",
   })
 


### PR DESCRIPTION
Format time and date based on browser regional settings.

For example:
Before - dates were formatted in US style for everyone:
![obraz](https://github.com/coracle-social/coracle/assets/12064267/7fab2756-b4ab-4e9c-8efe-3500dd74bd9f)

After - locale read from browser, for my country and language formatting will looks like:
![obraz](https://github.com/coracle-social/coracle/assets/12064267/dcc1f206-b76a-4031-b13b-f3339b90d235)

Solution based on https://stackoverflow.com/a/57529410