### PR TITLE
add a very basic docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:alpine as builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install
+
+COPY . .
+
+RUN yarn run build
+
+FROM nginx:alpine
+
+# Copy the static website files to the default Nginx serve directory
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+# Nginx will start automatically


### PR DESCRIPTION
Adds a very basic Docker build. Looking for feedback to make it better! 

I am building multiarch images on my machine:
```
docker buildx build --platform linux/amd64,linux/arm64 -t coracle:latest . --push
```

Originally I ran `yarn run build` outside of Docker, which was faster, but less self contained. I added some changes recently which builds it completely in Docker.

Hopefully this PR is useful!