### PR TITLE
switch name to display_name in UserProfile

### DIFF
--- a/src/app/views/UserProfile.svelte
+++ b/src/app/views/UserProfile.svelte
@@ -38,7 +38,7 @@
   </div>
   <div class="flex w-full flex-col gap-8">
     <Field label="Username">
-      <Input type="text" name="name" wrapperClass="flex-grow" bind:value={values.name}>
+      <Input type="text" name="name" wrapperClass="flex-grow" bind:value={values.display_name}>
         <i slot="before" class="fa-solid fa-user-astronaut" />
       </Input>
       <div slot="info">In most clients, this image will be shown on your profile page.</div>


### PR DESCRIPTION
In the case where a user has both their name and display_name set, they are unable to change the main identifier used for their profile.  Allowing them to set their display_name fixes this.