### PR TITLE
Accented Hashtags

### DIFF
--- a/src/util/notes.ts
+++ b/src/util/notes.ts
@@ -84,7 +84,7 @@ export const parseContent = (event: {content: string; tags?: string[][]}) => {
   }
 
   const parseTopic = () => {
-    const topic: string = first(text.match(/^#\w+/i))
+    const topic: string = first(text.match(/^#[\w\u00E0-\u00FC]+/i))
 
     // Skip numeric topics
     if (topic && !topic.match(/^#\d+$/)) {


### PR DESCRIPTION
fixes #281 

I adjusted the regex to include relevant [Latin-1 Supplement](https://en.wikipedia.org/wiki/Latin-1_Supplement) characters