### PR TITLE
Suppress nip46 exceptions

### DIFF
--- a/src/engine/network/utils/connect.ts
+++ b/src/engine/network/utils/connect.ts
@@ -95,10 +95,11 @@ export class NostrConnectBroker extends Emitter {
       window.open(auth_url, "Coracle", "width=600,height=800,popup=yes")
     })
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.once(`response-${id}`, ({result, error}) => {
         if (error) {
-          reject(error)
+          logger.error(error)
+          resolve(undefined)
         } else {
           resolve(result)
         }


### PR DESCRIPTION
Nip07 exceptions are suppressed - just printed into the logger using withExtension, but nip46 exceptions aren't caught, which means that DM handling of nip04 || nip44 is interrupted by nip04 exceptions and nip44 part is never called. This is the simplest way to overcome this..