### PR TITLE
Fix pubkey param in nip46 connect call

### DIFF
--- a/src/engine/network/utils/connect.ts
+++ b/src/engine/network/utils/connect.ts
@@ -117,7 +117,7 @@ export class NostrConnectBroker extends Emitter {
 
   async connect(token: string = null) {
     if (!this.#connectResult) {
-      const params = [getPublicKey(this.connectKey), token || "", Perms]
+      const params = [this.pubkey, token || "", Perms]
 
       this.#connectResult = await this.request("connect", params)
     }


### PR DESCRIPTION
The NIP46 requires remote_user_pubkey as first param.