### PR TITLE
fix broken hyperlink for LUD-16

### DIFF
--- a/src/app/views/UserProfile.svelte
+++ b/src/app/views/UserProfile.svelte
@@ -10,7 +10,7 @@
   import {router} from "src/app/util/router"
 
   const nip05Url = "https://github.com/nostr-protocol/nips/blob/master/05.md"
-  const lud16Url = "https://blog.getalby.com/create-your-neutral-300ning-address/"
+  const lud16Url = "https://github.com/lnurl/luds/blob/luds/16.md"
   const pseudUrl =
     "https://www.coindesk.com/markets/2020/06/29/many-bitcoin-developers-are-choosing-to-use-pseudonyms-for-good-reason/"
 


### PR DESCRIPTION
[https://blog.getalby.com/create-your-neutral-300ning-address/](https://blog.getalby.com/create-your-neutral-300ning-address/) is now 404 as witnessed in [https://archive.ph/Z3q8A](https://archive.ph/Z3q8A).

This PR updates the definition of lud16Url 
FROM: [https://blog.getalby.com/create-your-neutral-300ning-address/](https://blog.getalby.com/create-your-neutral-300ning-address/)  
TO: [https://github.com/lnurl/luds/blob/luds/16.md](https://github.com/lnurl/luds/blob/luds/16.md).