### PR TITLE
Improve NIP-17 UX

### DIFF
--- a/src/app/views/ChannelCreate.svelte
+++ b/src/app/views/ChannelCreate.svelte
@@ -35,8 +35,8 @@
     {#if hasGroupMemberWithoutInboxRelaysError}
       <p class="flex gap-2">
         <i class="fa fa-info-circle p-1" />
-        One the group members does not have inbox relays setup. It is required for all members of a group
-        chat to have inbox relays setup.
+        At least one of the group members does not have inbox relays setup. It is required for all members
+        of a group chat to have inbox relays setup.
       </p>
     {/if}
   </FlexColumn>

--- a/src/app/views/ChannelCreate.svelte
+++ b/src/app/views/ChannelCreate.svelte
@@ -5,14 +5,17 @@
   import Anchor from "src/partials/Anchor.svelte"
   import PersonSelect from "src/app/shared/PersonSelect.svelte"
   import {router} from "src/app/util/router"
-  import {pubkey, nip44} from "src/engine"
+  import {pubkey, nip44, deriveEveryUserHasInboxRelays} from "src/engine"
 
   let value = []
 
   const submit = () => router.at("channels").of(pubkeys).push()
 
   $: pubkeys = uniq(value.concat($pubkey))
-  $: hasError = pubkeys.length > 2 && !$nip44.isEnabled()
+  $: everyUserHasInboxRelays = deriveEveryUserHasInboxRelays(pubkeys)
+  $: hasLoginMethodThatDoesNotSupportNip44Error = pubkeys.length > 2 && !$nip44.isEnabled()
+  $: hasGroupMemberWithoutInboxRelaysError = pubkeys.length > 2 && !$everyUserHasInboxRelays
+  $: hasError = hasLoginMethodThatDoesNotSupportNip44Error || hasGroupMemberWithoutInboxRelaysError
 </script>
 
 <form on:submit|preventDefault={submit} class="flex justify-center py-12">
@@ -22,11 +25,18 @@
       <PersonSelect multiple autofocus bind:value />
     </Field>
     <Anchor disabled={hasError} button tag="button" type="submit">Done</Anchor>
-    {#if hasError}
+    {#if hasLoginMethodThatDoesNotSupportNip44Error}
       <p class="flex gap-2">
         <i class="fa fa-info-circle p-1" />
         You are using a login method that doesn't yet support group chats. Please consider upgrading
         your signer to access this feature.
+      </p>
+    {/if}
+    {#if hasGroupMemberWithoutInboxRelaysError}
+      <p class="flex gap-2">
+        <i class="fa fa-info-circle p-1" />
+        One the group members does not have inbox relays setup. It is required for all members of a group
+        chat to have inbox relays setup.
       </p>
     {/if}
   </FlexColumn>

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -1116,6 +1116,15 @@ export const inboxRelayLists = withGetter(
   }),
 )
 
+export const deriveInboxRelays = (pubkeys: string[]) =>
+  deriveEvents({filters: [{kinds: [INBOX_RELAYS], authors: pubkeys}]})
+
+export const deriveEveryUserHasInboxRelays = (pubkeys: string[]) =>
+  derived(
+    deriveInboxRelays(pubkeys),
+    $events => $events.length === pubkeys.length && $events.every(({tags}) => tags.length > 0),
+  )
+
 export const legacyRelayLists = withGetter(
   deriveEventsMapped<{event: TrustedEvent; policy: RelayPolicy[]}>({
     filters: [{kinds: [FOLLOWS]}],

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -277,7 +277,8 @@
       <p>
         {getMissingRecipientsMessage()}
       </p>
-    {:else if !currentUserHasInboxRelays}
+    {/if}
+    {#if !currentUserHasInboxRelays}
       <p>
         You are missing inbox relays.
         <Anchor href="/settings/relays">Click here to set up your inbox relays.</Anchor>

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -47,6 +47,12 @@
     $events =>
       $events.filter(({pubkey, tags}) => pubkey === $session?.pubkey && tags.length > 0).length > 0,
   )
+  const hasSingleRecipientWithInboxRelays = derived(
+    inboxRelays,
+    $events =>
+      !isGroupMessage &&
+      $events.filter(({pubkey, tags}) => pubkey !== $session?.pubkey && tags.length > 0).length > 0,
+  )
 
   let useNip17 = isGroupMessage || ($nip44.isEnabled() && $everyUserHasInboxRelays)
 
@@ -170,7 +176,7 @@
           <i class="fa-solid fa-paper-plane fa-lg" />
         </button>
       </div>
-      {#if $nip44.isEnabled() && !isGroupMessage}
+      {#if $nip44.isEnabled() && $hasSingleRecipientWithInboxRelays}
         <div class="fixed bottom-0 right-12 flex items-center justify-end gap-2 p-2">
           {#if !$currentUserHasInboxRelays && !isGroupMessage}
             <Popover triggerType="mouseenter">

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -34,8 +34,9 @@
   let limit = 10
   let showNewMessages = false
   let groupedMessages = []
+  const isGroupMessage = pubkeys.length > 2
   let useNip17 =
-    pubkeys.length > 2 ||
+    isGroupMessage ||
     ($nip44.isEnabled() &&
       repository.query([{kinds: [INBOX_RELAYS], authors: pubkeys}]).length === pubkeys.length)
 
@@ -132,7 +133,7 @@
       <div in:fly={{y: 20}} class="py-20 text-center">End of message history</div>
     {/await}
   </ul>
-  {#if $nip44.isEnabled() || pubkeys.length < 3}
+  {#if $nip44.isEnabled() || !isGroupMessage}
     <div
       class="flex border-t border-solid border-neutral-600 border-tinted-700 bg-neutral-900 dark:bg-neutral-600">
       <textarea
@@ -159,7 +160,7 @@
           <i class="fa-solid fa-paper-plane fa-lg" />
         </button>
       </div>
-      {#if $nip44.isEnabled()}
+      {#if $nip44.isEnabled() && !isGroupMessage}
         <div class="fixed bottom-0 right-12 flex items-center justify-end gap-2 p-2">
           <Toggle scale={0.7} bind:value={useNip17} />
           <small>

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -178,7 +178,9 @@
       </div>
       {#if $nip44.isEnabled() && $hasSingleRecipientWithInboxRelays}
         <div class="fixed bottom-0 right-12 flex items-center justify-end gap-2 p-2">
-          {#if !$currentUserHasInboxRelays && !isGroupMessage}
+          {#if $currentUserHasInboxRelays}
+            <Toggle scale={toggleScale} bind:value={useNip17} />
+          {:else}
             <Popover triggerType="mouseenter">
               <div slot="trigger">
                 <Toggle disabled scale={toggleScale} value={false} />
@@ -189,8 +191,6 @@
                 up your inbox relays.
               </Anchor>
             </Popover>
-          {:else}
-            <Toggle scale={toggleScale} bind:value={useNip17} />
           {/if}
           <small>
             Send messages using

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -3,7 +3,6 @@
   import {derived} from "svelte/store"
   import {sleep} from "@welshman/lib"
   import type {TrustedEvent} from "@welshman/util"
-  import {INBOX_RELAYS} from "@welshman/util"
   import {prop, max, reverse, pluck, sortBy, last} from "ramda"
   import {fly} from "src/util/transition"
   import {createScroller} from "src/util/misc"
@@ -13,7 +12,7 @@
   import Toggle from "src/partials/Toggle.svelte"
   import FlexColumn from "src/partials/FlexColumn.svelte"
   import ImageInput from "src/partials/ImageInput.svelte"
-  import {nip44, session, deriveEvents} from "src/engine"
+  import {nip44, session, deriveInboxRelays, deriveEveryUserHasInboxRelays} from "src/engine"
 
   export let pubkeys
   export let sendMessage
@@ -37,11 +36,8 @@
   let showNewMessages = false
   let groupedMessages = []
   const isGroupMessage = pubkeys.length > 2
-  const inboxRelays = deriveEvents({filters: [{kinds: [INBOX_RELAYS], authors: pubkeys}]})
-  const everyUserHasInboxRelays = derived(
-    inboxRelays,
-    $events => $events.length === pubkeys.length && $events.every(({tags}) => tags.length > 0),
-  )
+  const inboxRelays = deriveInboxRelays(pubkeys)
+  const everyUserHasInboxRelays = deriveEveryUserHasInboxRelays(pubkeys)
   const currentUserHasInboxRelays = derived(
     inboxRelays,
     $events =>


### PR DESCRIPTION
resolves https://github.com/coracle-social/coracle/issues/378

single recipient where current user doesn't have inbox relays
![Screenshot 2024-07-19 at 10 36 19 AM](https://github.com/user-attachments/assets/4c411f6a-adf9-4d12-abb2-ec8022731a68)

no nip-17 toggle for group messages
![Screenshot 2024-07-19 at 10 36 58 AM](https://github.com/user-attachments/assets/8fe5cf0f-deb1-4f22-9a86-0c156913cc19)

disable ability to start a group message if not all group members have inbox relays
![Screenshot 2024-07-19 at 10 38 04 AM](https://github.com/user-attachments/assets/8bf62ea3-8722-4b87-a4cf-5561332ec7e5)

display confirm screen when in group chat and at least one person is missing inbox relays
![Screenshot 2024-07-19 at 10 37 28 AM](https://github.com/user-attachments/assets/66b69534-637b-4d68-a3a9-ad091aeb8f8d)

![Screenshot 2024-07-19 at 10 46 31 AM](https://github.com/user-attachments/assets/e2fc62a5-d78f-46f8-aa21-b263fe69420c)
