### PR TITLE
fix desktop menu item spacing on short screens (<650px height)

### DIFF
--- a/src/app/MenuDesktopItem.svelte
+++ b/src/app/MenuDesktopItem.svelte
@@ -7,9 +7,11 @@
   export let path = null
   export let isActive = false
   export let small = false
+  export let short = innerHeight < 650
 
   $: className = cx("relative staatliches block transition-all", $$props.class, {
-    "h-12": !small,
+    "h-10": !small && short,
+    "h-12": !small && !short,
     "h-10 text-lg": small,
     "text-3xl": !small && isActive,
     "text-2xl": !small && !isActive,


### PR DESCRIPTION
Current view on desktop for shorter screens (I'm on a 13-inch macbook). The inspector said my browser window height was 595px with this:
<img width="356" alt="Screen Shot 2024-07-25 at 5 42 57 PM" src="https://github.com/user-attachments/assets/5abcf921-784b-4a29-8594-fe23435b9c06">

Suggested view:
<img width="368" alt="Screen Shot 2024-07-25 at 5 43 02 PM" src="https://github.com/user-attachments/assets/ab866b25-4e73-42b7-968f-9d1ca1b3333f">
