### PR TITLE
Add calendar view for single entity based on new path with npub

### DIFF
--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -132,6 +132,12 @@
       address: asNaddr("address"),
     },
   })
+  router.register("/events/people/:entity", Calendar, {
+    required: ["pubkey"],
+    serializers: {
+      entity: asPerson,
+    },
+  })
   router.register("/events/:address/edit", EventEdit, {
     serializers: {
       address: asNaddr("address"),

--- a/src/app/views/Calendar.svelte
+++ b/src/app/views/Calendar.svelte
@@ -4,9 +4,12 @@
   import Calendar from "src/app/shared/Calendar.svelte"
   import {env, loadCircleMessages, userFollows} from "src/engine"
 
+  const isCalendarForSingleEntity = window.location.pathname.startsWith("/events/people/")
   const filter = env.FORCE_GROUP
     ? {kinds: [31923], "#a": [env.FORCE_GROUP]}
-    : {kinds: [31923], authors: [$pubkey, ...$userFollows].filter(identity)}
+    : isCalendarForSingleEntity
+      ? {kinds: [31923], authors: [$pubkey].filter(identity)}
+      : {kinds: [31923], authors: [$pubkey, ...$userFollows].filter(identity)}
 
   if (env.FORCE_GROUP) {
     loadCircleMessages([env.FORCE_GROUP])


### PR DESCRIPTION
# Motivation and problem
Hello, as I've wrote in https://github.com/coracle-social/coracle/issues/434 , I really love the calendar mini-app in Coracle client and find it very useful for our organization.

But we also have a specific usecase, where we publish events (meetups and so on..), but need a single page for displaying ONLY OURS calendar events.

I didn't find such option in current coracle client, it can only parse single calendar event from url `coracle.social/events/naddr` , but I propose new additional possibility, where the client could also show calendar events based on specific `npub`.

Such that when I wanted to look at events that `Organization XY` is doing next month, I could go on `URL` and it would show me them - filtered.

# Proposed solution (that is done in commits)
First of all, let me just say that I don't have experience with Svelte for development of web apps, but I am experienced in React side of things. So I studied repo for a bit and found this solution.

1. I've added and registered new route `/events/people/:entity`
2. added check in `Calendar` componet, that if the route is `/events/people/` it should only show notes from that npub

<img width="900" alt="image" src="https://github.com/user-attachments/assets/8ed74557-8037-408b-b725-1ca282310d1e">

# Testing
I've tested the client and it doesn't break anything, normal calendar from UI works like before, but there's a new possibility to go from url path directly to single-entity-mode calendar.

I appreciate all of your work on Coracle and would really like to help with this. If you see any possibilities of improvement to the code, I'm open to it. Thanks

Fixes #434 