### PR TITLE
388 - Update the displayList implementation and move into the project

### DIFF
--- a/src/app/shared/FeedSummary.svelte
+++ b/src/app/shared/FeedSummary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {quantify, pluralize, displayList} from "hurdak"
+  import {quantify, pluralize} from "hurdak"
   import {
     isScopeFeed,
     isRelayFeed,
@@ -18,7 +18,7 @@
   } from "@welshman/feeds"
   import {displayRelayUrl} from "@welshman/util"
   import {displayProfileByPubkey} from "@welshman/app"
-  import {formatTimestampAsDate} from "src/util/misc"
+  import {displayList, formatTimestampAsDate} from "src/util/misc"
   import Chip from "src/partials/Chip.svelte"
 
   export let feed

--- a/src/app/views/ChannelCreate.svelte
+++ b/src/app/views/ChannelCreate.svelte
@@ -2,13 +2,14 @@
   import {derived} from "svelte/store"
   import {uniq} from "@welshman/lib"
   import {pubkey, displayProfileByPubkey, inboxRelaySelectionsByPubkey} from "@welshman/app"
-  import {displayList, pluralize} from "hurdak"
+  import {pluralize} from "hurdak"
   import Field from "src/partials/Field.svelte"
   import FlexColumn from "src/partials/FlexColumn.svelte"
   import Anchor from "src/partials/Anchor.svelte"
   import PersonSelect from "src/app/shared/PersonSelect.svelte"
   import {router} from "src/app/util/router"
   import {hasNip44} from "src/engine"
+  import {displayList} from "src/util/misc"
 
   let value = []
 

--- a/src/app/views/ChannelsListItem.svelte
+++ b/src/app/views/ChannelsListItem.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import {without} from "ramda"
-  import {displayList} from "hurdak"
   import {derived} from "svelte/store"
   import {pubkey, profiles, displayProfileByPubkey} from "@welshman/app"
   import PersonCircles from "src/app/shared/PersonCircles.svelte"
   import Card from "src/partials/Card.svelte"
   import {router} from "src/app/util/router"
   import {channelHasNewMessages} from "src/engine"
+  import {displayList} from "src/util/misc"
 
   export let channel
 

--- a/src/app/views/RelayList.svelte
+++ b/src/app/views/RelayList.svelte
@@ -2,7 +2,6 @@
   import {onMount} from "svelte"
   import {derived} from "svelte/store"
   import {groupBy, sortBy, uniq} from "ramda"
-  import {displayList} from "hurdak"
   import {ctx, pushToMapKey} from "@welshman/lib"
   import {
     pubkey,
@@ -18,7 +17,7 @@
     relaySelectionsByPubkey,
   } from "@welshman/app"
   import {Tags, isShareableRelayUrl, normalizeRelayUrl, profileHasName} from "@welshman/util"
-  import {createScroller} from "src/util/misc"
+  import {createScroller, displayList} from "src/util/misc"
   import {showWarning} from "src/partials/Toast.svelte"
   import Tabs from "src/partials/Tabs.svelte"
   import Modal from "src/partials/Modal.svelte"

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import cx from "classnames"
   import {onMount} from "svelte"
-  import {displayList, pluralize} from "hurdak"
+  import {pluralize} from "hurdak"
   import {derived} from "svelte/store"
   import {sleep, remove} from "@welshman/lib"
   import type {TrustedEvent} from "@welshman/util"
@@ -14,7 +14,7 @@
   } from "@welshman/app"
   import {prop, max, reverse, pluck, sortBy, last} from "ramda"
   import {fly, slide} from "src/util/transition"
-  import {createScroller, formatTimestamp} from "src/util/misc"
+  import {createScroller, displayList, formatTimestamp} from "src/util/misc"
   import Spinner from "src/partials/Spinner.svelte"
   import Anchor from "src/partials/Anchor.svelte"
   import Popover from "src/partials/Popover.svelte"

--- a/src/partials/ImageInput.svelte
+++ b/src/partials/ImageInput.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import {createEventDispatcher} from "svelte"
-  import {displayList} from "hurdak"
   import Input from "src/partials/Input.svelte"
   import Modal from "src/partials/Modal.svelte"
   import Spinner from "src/partials/Spinner.svelte"
   import Anchor from "src/partials/Anchor.svelte"
   import {listenForFile} from "src/util/html"
   import {uploadFiles, getSetting} from "src/engine"
+  import {displayList} from "src/util/misc"
 
   export let icon = null
   export let value = null

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -332,6 +332,20 @@ export const toSpliced = <T>(xs: T[], start: number, deleteCount: number = 0, ..
   ...xs.slice(start + deleteCount),
 ]
 
+export const displayList = <T>(xs: T[], conj = "and", n = 6, locale = "en-US") => {
+  // Convert all elements to strings for Intl.ListFormat
+  const stringItems = xs.map(String)
+
+  if (xs.length > n + 2) {
+    const formattedList = new Intl.ListFormat(locale, {style: "long", type: "unit"}).format(
+      stringItems.slice(0, n),
+    )
+    return `${formattedList}, ${conj} ${xs.length - n} others`
+  }
+
+  return new Intl.ListFormat(locale, {style: "long", type: "conjunction"}).format(stringItems)
+}
+
 // Local storage
 
 export const synced = <T>(key: string, defaultValue: T, delay = 300) => {

--- a/tests/unit/util/misc.spec.ts
+++ b/tests/unit/util/misc.spec.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from "vitest"
+import {displayList} from "../../../src/util/misc"
+
+describe("misc utils", () => {
+  describe("displayList", () => {
+    it("should return an empty string when the list is empty", () => {
+      const list = []
+      const output = displayList(list)
+
+      expect(output).toEqual("")
+    })
+
+    it("should return a single entry when list length is one", () => {
+      const list = ["Apple"]
+      const output = displayList(list)
+
+      expect(output).toEqual("Apple")
+    })
+
+    it("should return a string of both items when the list length is two", () => {
+      const list = ["Apple", "Banana"]
+      const output = displayList(list)
+
+      expect(output).toEqual("Apple and Banana")
+    })
+
+    it("should return a string of all items when the list length is three", () => {
+      const list = ["Apple", "Banana", "Cherry"]
+      const output = displayList(list)
+
+      expect(output).toEqual("Apple, Banana, and Cherry")
+    })
+
+    it("should return a truncated string of all items when the list is long", () => {
+      const list = [
+        "Apple",
+        "Banana",
+        "Orange",
+        "Pear",
+        "Grapes",
+        "Mango",
+        "Pineapple",
+        "Kiwi",
+        "Strawberry",
+        "Blueberry",
+      ]
+      const output = displayList(list)
+
+      expect(output).toEqual("Apple, Banana, Orange, Pear, Grapes, Mango, and 4 others")
+    })
+
+    it("should return a string of both items with list of two numbers", () => {
+      const list = [7, 17]
+      const output = displayList(list)
+
+      expect(output).toEqual("7 and 17")
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "module": "esnext",
+    "target": "es2021",
     "paths": {
       "src/*": ["src/*"]
     },


### PR DESCRIPTION
This PR addresses #388. Pulled `displayList` into the project and made use of `Intl.ListFormt` instead of pure string concatenation. Maybe this is a slight improvement to the hurdak implementation? Added unit tests, so hopefully the original functionality is maintained. Also `tsconfig` was not happy, saying `Intl.ListFormat` did not exist, so I pointed the tsconfig target to `es2021` so we could have access to it. Not sure about the broader implications of this change.