### PR TITLE
Use pubkey relay if naddr does not provide relay hints

### DIFF
--- a/src/app/views/Bech32Entity.svelte
+++ b/src/app/views/Bech32Entity.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {Address} from "@welshman/util"
   import {loadHandle} from "@welshman/app"
+  import {ctx} from "@welshman/lib"
   import Content from "src/partials/Content.svelte"
   import Spinner from "src/partials/Spinner.svelte"
   import NoteDetail from "src/app/views/NoteDetail.svelte"
@@ -16,10 +17,14 @@
   <NoteDetail id={data} {relays} />
 {:else if type === "naddr"}
   {@const address = new Address(data.kind, data.pubkey, data.identifier).toString()}
+  {@const relays = [
+    ...(data.relays || []),
+    ...Array.from(ctx.app.router.FromPubkey(data.pubkey).getUrls()),
+  ]}
   {#if data.kind === 31923}
-    <EventDetail {address} relays={data.relays} />
+    <EventDetail {address} {relays} />
   {:else}
-    <NoteDetail {address} relays={data.relays} />
+    <NoteDetail {address} {relays} />
   {/if}
 {:else if type === "nprofile"}
   <PersonDetail pubkey={data.pubkey} {relays} />

--- a/src/engine/requests.ts
+++ b/src/engine/requests.ts
@@ -20,6 +20,7 @@ import {
   HANDLER_RECOMMENDATION,
   DEPRECATED_DIRECT_MESSAGE,
   FEEDS,
+  Address,
 } from "@welshman/util"
 import {Tracker} from "@welshman/net"
 import {deriveEvents} from "@welshman/store"
@@ -114,6 +115,10 @@ export const deriveEvent = (idOrAddress: string, request: Partial<MySubscribeReq
     deriveEvents(repository, {filters, includeDeleted: true}),
     (events: TrustedEvent[]) => {
       if (!attempted && events.length === 0) {
+        if (Address.isAddress(idOrAddress) && !request.relays) {
+          const {pubkey, relays} = Address.from(idOrAddress)
+          request.relays = uniq([...relays, ...ctx.app.router.ForPubkey(pubkey).getUrls()])
+        }
         loadEvent(idOrAddress, request)
         attempted = true
       }


### PR DESCRIPTION
Fallback to the pubkey write relays when naddr to not provide relay hints.

In deriveEvents, when loading the event, make sure we have some relay set in the request.
In NoteDetails and EventDetails, make sure we pass in some relays url so that we can load the event in the onMount callback

#448 
