### PR TITLE
Fix link editor (for good)

### DIFF
--- a/src/app/editor/LinkExtension.ts
+++ b/src/app/editor/LinkExtension.ts
@@ -74,27 +74,28 @@ export const LinkExtension = Node.create({
               index: match.index!,
               text: match[0],
               data: {
-                url: match[0],
+                url: match[0].trim(),
               },
             }
           }
 
           return null
         },
-        handler: ({state, range, match, chain}) => {
-          const {tr} = state
+        handler: ({range, match, chain}) => {
           if (match[0]) {
-            try {
-              chain()
-                .deleteRange({from: range.from - 1, to: range.from - 1 + match[0].length})
-                .insertLink({url: match[0]})
-                .run()
-            } catch (e) {
-              // If the node was already linkified, the above code breaks for whatever reason
-            }
-          }
+            const lastChar = last(Array.from(match.input!))
+            const chainCommand = chain()
+              .deleteRange({from: range.from - 1, to: range.from - 1 + match[0].length})
+              .insertLink({url: match[0]})
 
-          tr.scrollIntoView()
+            if (lastChar === "\n") {
+              chainCommand.splitBlock()
+            } else {
+              chainCommand.insertContent(" ")
+            }
+
+            chainCommand.run()
+          }
         },
       }),
     ]


### PR DESCRIPTION
#473 

Have removed this bug that was a range error from tiptap.

Have tried many different commands to keep the range correct but nothing worked.
The solution I have is not the most elegant but it works everytime. Taking the real input being tracked by tiptap from (editor.state.doc.textContent) and check if there is a match against it, this avoid linkifying twice (which was the root issue)

Also the behaviour is slightly better now, on the previous version pressing enter and then space after creating a link would cancel the line break.
