### PR TITLE
Refine delayed send

### DIFF
--- a/src/app/shared/Note.svelte
+++ b/src/app/shared/Note.svelte
@@ -32,6 +32,7 @@
   import NoteActions from "src/app/shared/NoteActions.svelte"
   import NoteContent from "src/app/shared/NoteContent.svelte"
   import NotePending from "src/app/shared/NotePending.svelte"
+  import {drafts} from "src/app/state"
   import {router} from "src/app/util/router"
   import {
     env,
@@ -74,7 +75,12 @@
 
   const addDraftToContext = (event, cb) => {
     draftEventId = event.id
-    removeDraft = () => cb() && repository.removeEvent(event.id)
+    removeDraft = () => {
+      cb()
+      repository.removeEvent(event.id)
+      drafts.set(note.id, event.content)
+      replyIsActive = false
+    }
   }
 
   const onClick = e => {
@@ -290,6 +296,7 @@
                   note={event}
                   zapper={$zapper}
                   {replyCtrl}
+                  {replyIsActive}
                   {showHidden}
                   {replies}
                   {likes}

--- a/src/app/shared/Note.svelte
+++ b/src/app/shared/Note.svelte
@@ -78,7 +78,6 @@
     draftEventId = event.id
     removeDraft = () => {
       cb()
-      repository.removeEvent(event.id)
       drafts.set(note.id, event.content)
       sleep(10).then(() => {
         replyCtrl?.start()

--- a/src/app/shared/Note.svelte
+++ b/src/app/shared/Note.svelte
@@ -14,6 +14,7 @@
   } from "@welshman/util"
   import {repository, deriveZapperForPubkey, deriveZapper} from "@welshman/app"
   import {deriveEvents} from "@welshman/store"
+  import {sleep} from "hurdak"
   import {identity, uniqBy, prop} from "ramda"
   import {onMount} from "svelte"
   import {quantify} from "hurdak"
@@ -79,7 +80,9 @@
       cb()
       repository.removeEvent(event.id)
       drafts.set(note.id, event.content)
-      replyIsActive = false
+      sleep(10).then(() => {
+        replyCtrl?.start()
+      })
     }
   }
 
@@ -296,7 +299,6 @@
                   note={event}
                   zapper={$zapper}
                   {replyCtrl}
-                  {replyIsActive}
                   {showHidden}
                   {replies}
                   {likes}

--- a/src/app/shared/NoteActions.svelte
+++ b/src/app/shared/NoteActions.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import cx from "classnames"
   import {nip19} from "nostr-tools"
+  import {sum, pluck} from "ramda"
   import {onMount} from "svelte"
+  import {tweened} from "svelte/motion"
   import {derived} from "svelte/store"
-  import {slide} from "svelte/transition"
   import {ctx, nth, nthEq, remove, last, sortBy} from "@welshman/lib"
   import {
     repository,
@@ -23,8 +24,6 @@
     createEvent,
     getPubkeyTagValues,
   } from "@welshman/util"
-  import {tweened} from "svelte/motion"
-  import {sum, pluck} from "ramda"
   import {fly} from "src/util/transition"
   import {formatSats} from "src/util/misc"
   import {quantify, pluralize} from "hurdak"
@@ -61,7 +60,6 @@
   export let note: TrustedEvent
   export let muted
   export let replyCtrl
-  export let replyIsActive = false
   export let showHidden
   export let replies, likes, zaps
   export let zapper
@@ -231,16 +229,6 @@
   class="flex justify-between text-neutral-100"
   on:click|stopPropagation>
   <div class="flex gap-8 text-sm">
-    {#if replyIsActive}
-      <button
-        class="relative flex items-center gap-1 rounded-md px-4 text-xs uppercase"
-        class:border={!replyIsActive}
-        class:bg-accent={replyIsActive}
-        transition:slide|local={{axis: "x", duration: 100}}
-        on:click={replyCtrl?.start}>
-        Reply
-      </button>
-    {/if}
     <button
       class={cx("relative flex items-center gap-1 pt-1 transition-all hover:pb-1 hover:pt-0", {
         "pointer-events-none opacity-50": disableActions,

--- a/src/app/shared/NoteActions.svelte
+++ b/src/app/shared/NoteActions.svelte
@@ -3,6 +3,7 @@
   import {nip19} from "nostr-tools"
   import {onMount} from "svelte"
   import {derived} from "svelte/store"
+  import {slide} from "svelte/transition"
   import {ctx, nth, nthEq, remove, last, sortBy} from "@welshman/lib"
   import {
     repository,
@@ -60,6 +61,7 @@
   export let note: TrustedEvent
   export let muted
   export let replyCtrl
+  export let replyIsActive = false
   export let showHidden
   export let replies, likes, zaps
   export let zapper
@@ -229,6 +231,16 @@
   class="flex justify-between text-neutral-100"
   on:click|stopPropagation>
   <div class="flex gap-8 text-sm">
+    {#if replyIsActive}
+      <button
+        class="relative flex items-center gap-1 rounded-md px-4 text-xs uppercase"
+        class:border={!replyIsActive}
+        class:bg-accent={replyIsActive}
+        transition:slide|local={{axis: "x", duration: 100}}
+        on:click={replyCtrl?.start}>
+        Reply
+      </button>
+    {/if}
     <button
       class={cx("relative flex items-center gap-1 pt-1 transition-all hover:pb-1 hover:pt-0", {
         "pointer-events-none opacity-50": disableActions,

--- a/src/app/shared/NotePending.svelte
+++ b/src/app/shared/NotePending.svelte
@@ -74,7 +74,14 @@
       <span>Publishing...</span>
       <span>{total - pendings} of {total} relays</span>
     {:else}
-      <span>Published to {success}/{total} ({failed} failed, {timeout} timed out)</span>
+      <span
+        >Published to {success}/{total}
+        {#if failed > 0 || timeout > 0}
+          ({failed > 0 ? failed + " failed" : ""}{timeout > 0
+            ? (failed > 0 ? ", " : "") + timeout + " timed out"
+            : ""})
+        {/if}
+      </span>
       <Anchor
         class="staatliches z-feature rounded-r-md bg-tinted-100-d px-4 py-1 uppercase text-tinted-700-d"
         modal

--- a/src/app/shared/NotePending.svelte
+++ b/src/app/shared/NotePending.svelte
@@ -66,6 +66,7 @@
 <div
   class="loading-bar-content relative flex h-6 w-full items-center justify-between overflow-hidden rounded-md pl-4 text-sm"
   class:bg-neutral-500={thunk && (isPending || isCompleted)}
+  class:border={!(isPending || isCompleted)}
   class:px-4={thunk && isPending}
   on:click|stopPropagation>
   {#if thunk && (isPending || isCompleted)}
@@ -88,7 +89,7 @@
         href="/publishes">See details</Anchor>
     {/if}
   {:else if $userSettings.send_delay > 0}
-    <span class="-ml-4"
+    <span
       >Sending reply in {rendered + Math.ceil($userSettings.send_delay / 1000) - $timestamp1} seconds</span>
 
     <button

--- a/src/app/shared/NoteReply.svelte
+++ b/src/app/shared/NoteReply.svelte
@@ -102,7 +102,9 @@
     loading = true
 
     const template = createEvent(1, {content, tags})
+
     const event = await sign(template, {anonymous: false})
+
     const thunk = publish({
       event,
       relays: ctx.app.router.PublishEvent(event).getUrls(),

--- a/src/partials/Toast.svelte
+++ b/src/partials/Toast.svelte
@@ -91,13 +91,13 @@
 </script>
 
 {#if $toast}
-  <div
-    on:touchstart={onTouchStart}
-    on:touchmove={onTouchMove}
-    on:touchend={onTouchEnd}
-    class="pointer-events-none fixed left-0 right-0 top-0 z-toast flex justify-center"
-    transition:fly={{y: -50, duration: 300}}>
-    {#key $toast.id}
+  {#key $toast.id}
+    <div
+      on:touchstart={onTouchStart}
+      on:touchmove={onTouchMove}
+      on:touchend={onTouchEnd}
+      class="pointer-events-none fixed left-0 right-0 top-0 z-toast flex justify-center"
+      transition:fly={{y: -50, duration: 300}}>
       <div
         style={`transform: translate(${offset}px, 0)`}
         class={cx(
@@ -127,6 +127,6 @@
           <i class="fa fa-times" />
         </div>
       </div>
-    {/key}
-  </div>
+    </div>
+  {/key}
 {/if}


### PR DESCRIPTION
NoteCreate:
- Close the modal once the event is signed
- Re-open the modal when/if the sent is cancelled
- Keep an entry in the draft store with id "note-create" to keep the note content during the modal lifecycle

NoteReply:
- Save the draft if the send is cancelled
- Align the note content text with the countdown text
- loading start at 20% to the left, the loading bar is now tweened animated rather than spring animated, for a smoother look
- The loading bar has a lighter background now as Daniele's screenshot
- When a Note is being replied, a reply with a background accent appear on the parent note, per Daniele's screenshot.
- The thing missing from Daniele's screenshot is the action popover next to the loading bar, the note actions (deleted, broadcast repost etc) can only be used once the event is actually uploaded to one relay, so it should probably slide in before the upload is complete, let me know if I should add it anyway.