### PR TITLE
Enhance suggestions dropdown #486

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -92,6 +92,10 @@ body,
     -3px -3px 20px rgba(0, 0, 0, 0.1);
 }
 
+.tippy-content {
+  padding: 0 !important;
+}
+
 .tippy-box[data-theme~="dark"][data-placement^="top"] > .tippy-arrow {
   bottom: -1px !important;
 }

--- a/src/app/editor/SuggestionProfile.svelte
+++ b/src/app/editor/SuggestionProfile.svelte
@@ -22,11 +22,11 @@
 
 <div class="flex max-w-full gap-3">
   <div class="py-1">
-    <PersonCircle {pubkey} />
+    <PersonCircle {pubkey} class="h-10 w-10" />
   </div>
   <div class="flex min-w-0 flex-col">
     <div class="flex items-center gap-2">
-      <div class="text-bold overflow-hidden text-ellipsis">
+      <div class="text-bold overflow-hidden text-ellipsis text-base">
         {$profileDisplay}
       </div>
       <WotScore score={$score} accent={following} />

--- a/src/app/editor/Suggestions.svelte
+++ b/src/app/editor/Suggestions.svelte
@@ -94,4 +94,12 @@
       Loading more options...
     </div>
   {/if}
+  {#if !items.length && !loading}
+    <div class="flex gap-2 px-4 py-2 text-base">
+      <div>
+        <i class="fa fa-exclamation-circle" />
+      </div>
+      No results
+    </div>
+  {/if}
 {/if}


### PR DESCRIPTION
Flotilla inspired suggestion dropdown

- Picture profile is now twice bigger
- User name display is bigger
- zero padding in the tippy-content container
- Display "no results" if no profiles are found

https://github.com/user-attachments/assets/082fa20c-0284-46e5-9abb-f11dbc1bc2b8

