### PR TITLE
inbox warning

### DIFF
--- a/src/app/views/ChannelsDetail.svelte
+++ b/src/app/views/ChannelsDetail.svelte
@@ -61,7 +61,7 @@
           href={"/channels" + (isAccepted ? "" : "/requests")} />
         <PersonCircles {pubkeys} />
       </div>
-      <div class="flex flex-col items-start overflow-hidden pt-2">
+      <div class:h-16={pubkeys.length == 1} class="flex flex-col items-start overflow-hidden pt-2">
         <div>
           {#each pubkeys as pubkey, i (pubkey)}
             {#if i > 0}&bullet;{/if}

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -4,7 +4,7 @@
   import {pluralize} from "hurdak"
   import {derived} from "svelte/store"
   import {sleep} from "@welshman/lib"
-  import type {TrustedEvent} from "@welshman/util"
+  import {getListTags, type TrustedEvent} from "@welshman/util"
   import {Nip46Signer} from "@welshman/signer"
   import {
     session,
@@ -64,11 +64,7 @@
   let groupedMessages = []
 
   const pubkeysWithoutInbox = derived(inboxRelaySelectionsByPubkey, $inboxRelayPoliciesByPubkey =>
-    pubkeys.filter(
-      pubkey =>
-        !$inboxRelayPoliciesByPubkey.has(pubkey) ||
-        !$inboxRelayPoliciesByPubkey.get(pubkey).publicTags.length,
-    ),
+    pubkeys.filter(pubkey => !getListTags($inboxRelayPoliciesByPubkey.get(pubkey)).length),
   )
 
   onMount(() => {

--- a/src/partials/Channel.svelte
+++ b/src/partials/Channel.svelte
@@ -64,7 +64,11 @@
   let groupedMessages = []
 
   const pubkeysWithoutInbox = derived(inboxRelaySelectionsByPubkey, $inboxRelayPoliciesByPubkey =>
-    pubkeys.filter(pubkey => !$inboxRelayPoliciesByPubkey.has(pubkey)),
+    pubkeys.filter(
+      pubkey =>
+        !$inboxRelayPoliciesByPubkey.has(pubkey) ||
+        !$inboxRelayPoliciesByPubkey.get(pubkey).publicTags.length,
+    ),
   )
 
   onMount(() => {
@@ -176,6 +180,16 @@
         </div>
       {/if}
     </div>
+    {#if !userHasInbox}
+      <div class="m-auto max-w-96 py-20 text-center">
+        <div class="mb-4 text-lg text-accent">
+          <i class="fa fa-exclamation-triangle"></i> Your inbox is not configured.
+        </div>
+        In order to deliver messages, Coracle needs to know where to send them. Please visit your
+        <a class="cursor-pointer underline" href="/settings/relays"> relay settings page</a> and set
+        up your inbox relays.
+      </div>
+    {/if}
     {#each groupedMessages as message (message.id)}
       <div in:fly={{y: 20}} class="grid gap-2 py-1">
         <div


### PR DESCRIPTION
What it looks like at the bottom of the chat history
<img width="1418" alt="Screenshot 2024-11-25 at 16 47 52" src="https://github.com/user-attachments/assets/6cafeb33-7e91-4c63-86ec-6d74d1e9f351">

There is another warning, once the user hit send, in a confirmation modal. You probably want to remove this one.
<img width="713" alt="Screenshot 2024-11-25 at 16 49 36" src="https://github.com/user-attachments/assets/7995f9c5-1d5d-4126-84eb-785ca3e9ac2a">

There was also an issue once you remove all your inbox relay, your npub still exist in the inboxPoliciesByPubkey store mapping, but the publicTags list is empty. I took this into consideration as well to check if you have any inbox relay.