### PR TITLE
Prefix all entities with nostr:

### DIFF
--- a/src/app/editor/index.ts
+++ b/src/app/editor/index.ts
@@ -108,6 +108,7 @@ export const getEditorOptions = ({
     Bolt11Extension.extend(asInline({addNodeView: () => SvelteNodeViewRenderer(EditBolt11)})),
     NProfileExtension.extend({
       addNodeView: () => SvelteNodeViewRenderer(EditMention),
+      renderText: props => "nostr:" + props.node.attrs.nprofile,
       addProseMirrorPlugins() {
         return [
           createSuggestions({
@@ -127,8 +128,18 @@ export const getEditorOptions = ({
         ]
       },
     }),
-    NEventExtension.extend(asInline({addNodeView: () => SvelteNodeViewRenderer(EditEvent)})),
-    NAddrExtension.extend(asInline({addNodeView: () => SvelteNodeViewRenderer(EditEvent)})),
+    NEventExtension.extend(
+      asInline({
+        addNodeView: () => SvelteNodeViewRenderer(EditEvent),
+        renderText: props => "nostr:" + props.node.attrs.nevent,
+      }),
+    ),
+    NAddrExtension.extend(
+      asInline({
+        addNodeView: () => SvelteNodeViewRenderer(EditEvent),
+        renderText: props => "nostr:" + props.node.attrs.naddr,
+      }),
+    ),
     ImageExtension.extend(
       asInline({addNodeView: () => SvelteNodeViewRenderer(EditMedia)}),
     ).configure({defaultUploadUrl, defaultUploadType: uploadType}),


### PR DESCRIPTION
It's a small config in nostr-editor extensions, just extend renderText to add `nostr:` in front of nevent, naddr, nprofile.

If we expect those entities to always be prefixed by `nostr:`it might be worth a PR on nostr-editor