### PR TITLE
Refine Modals

### DIFF
--- a/src/app/MenuDesktop.svelte
+++ b/src/app/MenuDesktop.svelte
@@ -71,7 +71,7 @@
   $: userDisplay = deriveProfileDisplay($pubkey)
 </script>
 
-<div class="fixed bottom-0 left-0 top-0 z-nav w-72 bg-tinted-700 transition-colors">
+<div class="fixed bottom-0 left-0 top-0 z-modal w-72 bg-tinted-700 transition-colors">
   <Anchor external class="mb-4 mt-4 flex items-center gap-2 px-6" href="https://coracle.tools">
     <img
       alt="App Logo"

--- a/src/app/Routes.svelte
+++ b/src/app/Routes.svelte
@@ -75,7 +75,7 @@
 
 {#each [...$modals].reverse().filter(m => !m.virtual) as m, i (router.getKey(m) + i)}
   {@const {component} = router.getMatch(m.path).route}
-  <Modal mini={m.mini} virtual={false} canClose={!m.noEscape}>
+  <Modal mini={m.mini} drawer={m.drawer} virtual={false} canClose={!m.noEscape}>
     <svelte:component this={component} {...router.getProps(m)} />
   </Modal>
 {/each}

--- a/src/app/Routes.svelte
+++ b/src/app/Routes.svelte
@@ -54,7 +54,13 @@
       }
     }
   }
+
+  let innerWidth
+
+  $: isMobile = innerWidth < 768
 </script>
+
+<svelte:window bind:innerWidth />
 
 {#key $pubkey}
   <div
@@ -75,7 +81,7 @@
 
 {#each [...$modals].reverse().filter(m => !m.virtual) as m, i (router.getKey(m) + i)}
   {@const {component} = router.getMatch(m.path).route}
-  <Modal mini={m.mini} drawer={m.drawer} virtual={false} canClose={!m.noEscape}>
+  <Modal mini={m.mini} drawer={!isMobile && m.drawer} virtual={false} canClose={!m.noEscape}>
     <svelte:component this={component} {...router.getProps(m)} />
   </Modal>
 {/each}

--- a/src/partials/Modal.svelte
+++ b/src/partials/Modal.svelte
@@ -106,25 +106,22 @@
         class="fixed inset-0 cursor-pointer bg-black opacity-50"
         on:click|stopPropagation={tryClose} />
       <div
-        class="modal-content h-full overflow-auto"
+        class="modal-content ml-0 h-full overflow-auto lg:ml-72"
         class:overflow-hidden={mini}
         class:pointer-events-none={mini}
         use:swipe
         on:swipe={handleSwipe}
         on:end={handleSwipeEnd}
-        transition:fly={drawer ? {x: -1000} : {y: 1000}}
+        transition:fly={{y: 1000}}
         style="margin-top: {$translateY}px;"
         bind:this={content}>
         <div
-          class="pointer-events-auto mt-12 min-h-full flex-row-reverse justify-end transition-all duration-500"
-          class:flex={drawer}
-          class:mt-0={drawer}
+          class="pointer-events-auto flex min-h-full flex-col justify-center transition-all duration-500"
+          class:mt-12={!drawer}
           class:mt-[55vh]={mini}>
           {#if canClose}
             <div
-              class="pointer-events-none sticky top-0 z-popover flex w-full flex-col items-end gap-2 p-2"
-              class:w-auto={drawer}
-              class:fixed={drawer}>
+              class="pointer-events-none sticky top-0 z-popover mx-auto flex w-full max-w-4xl flex-col items-end gap-2 p-2">
               <div
                 class="pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-full
                      border border-solid border-accent bg-accent text-white transition-colors hover:bg-accent"
@@ -136,32 +133,16 @@
                 class:hidden={!isNested || !canCloseAll}
                 class="clear-modals pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center
                        rounded-full border border-solid border-tinted-700 bg-neutral-600 text-neutral-100 transition-colors hover:bg-neutral-600">
-                <i
-                  class={cx(
-                    {"fa-angles-left": drawer, "fa-angles-down": !drawer},
-                    "fa fa-angles-left fa-lg",
-                  )} />
+                <i class="fa-angles-down fa fa-lg" />
               </div>
             </div>
           {/if}
-          {#if !drawer}
-            <AltColor background class="absolute mt-12 h-full w-full" />
-          {/if}
-          <div
-            on:click|stopPropagation
-            class:w-full={drawer}
-            class:border-l={drawer}
-            class:max-w-screen-md={drawer}>
+          <div on:click|stopPropagation class="">
             <AltColor
               background
               class={cx(
-                {
-                  "rounded-t-none": drawer,
-                  "rounded-r-2xl": drawer,
-                  "h-screen": drawer,
-                  "overflow-scroll": drawer,
-                },
-                "relative w-full cursor-auto  rounded-t-2xl pb-20 pt-2",
+                {"min-h-screen": !drawer, "pb-4": drawer, "rounded-b-2xl": drawer},
+                "relative m-auto h-full w-full max-w-3xl cursor-auto overflow-hidden rounded-t-2xl pb-20 pt-2",
               )}>
               <div class="modal-content-inner m-auto flex max-w-2xl flex-col gap-4 p-2">
                 <slot />
@@ -169,7 +150,7 @@
             </AltColor>
           </div>
           {#if drawer}
-            <div class="hidden w-72 shrink-0 sm:block" />
+            <div class="h-12" />
           {/if}
         </div>
       </div>

--- a/src/partials/Modal.svelte
+++ b/src/partials/Modal.svelte
@@ -117,11 +117,11 @@
         bind:this={content}>
         <div
           class="pointer-events-auto flex min-h-full flex-col justify-center transition-all duration-500"
-          class:mt-12={!drawer}
+          class:mt-12={drawer}
           class:mt-[55vh]={mini}>
           {#if canClose}
             <div
-              class="pointer-events-none sticky top-0 z-popover mx-auto flex w-full max-w-4xl flex-col items-end gap-2 p-2">
+              class="pointer-events-none sticky top-0 z-popover mx-auto flex w-full max-w-3xl flex-col items-end gap-2 p-2">
               <div
                 class="pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-full
                      border border-solid border-accent bg-accent text-white transition-colors hover:bg-accent"
@@ -141,15 +141,15 @@
             <AltColor
               background
               class={cx(
-                {"min-h-screen": !drawer, "pb-4": drawer, "rounded-b-2xl": drawer},
-                "relative m-auto h-full w-full max-w-3xl cursor-auto overflow-hidden rounded-t-2xl pb-20 pt-2",
+                {"min-h-screen": drawer, "rounded-b-2xl": !drawer},
+                "relative m-auto h-full w-full max-w-2xl cursor-auto overflow-hidden rounded-t-2xl",
               )}>
-              <div class="modal-content-inner m-auto flex max-w-2xl flex-col gap-4 p-2">
+              <div class="modal-content-inner m-auto flex max-w-2xl flex-col gap-4 p-4">
                 <slot />
               </div>
             </AltColor>
           </div>
-          {#if drawer}
+          {#if !drawer}
             <div class="h-12" />
           {/if}
         </div>

--- a/src/partials/Modal.svelte
+++ b/src/partials/Modal.svelte
@@ -121,7 +121,7 @@
           class:mt-[55vh]={mini}>
           {#if canClose}
             <div
-              class="pointer-events-none sticky top-0 z-popover mx-auto flex w-full max-w-3xl flex-col items-end gap-2 p-2">
+              class="pointer-events-none sticky top-0 z-popover mx-auto flex min-h-16 w-full flex-col items-end gap-2 p-2">
               <div
                 class="pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-full
                      border border-solid border-accent bg-accent text-white transition-colors hover:bg-accent"
@@ -140,18 +140,12 @@
           <div on:click|stopPropagation class="">
             <AltColor
               background
-              class={cx(
-                {"min-h-screen": drawer, "rounded-b-2xl": !drawer},
-                "relative m-auto h-full w-full max-w-2xl cursor-auto overflow-hidden rounded-t-2xl",
-              )}>
+              class={cx("relative m-auto h-full min-h-screen w-full cursor-auto overflow-hidden")}>
               <div class="modal-content-inner m-auto flex max-w-2xl flex-col gap-4 p-4">
                 <slot />
               </div>
             </AltColor>
           </div>
-          {#if !drawer}
-            <div class="h-12" />
-          {/if}
         </div>
       </div>
     </div>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 import type {NetContext} from "@welshman/net"
 import type {AppContext} from "@welshman/app"
+import type {SwipeCustomEvent} from "src/util/swipe"
 
 declare module "fuse.js/dist/fuse.min.js"
 
@@ -7,5 +8,11 @@ declare module "@welshman/lib" {
   interface Context {
     net: NetContext
     app: AppContext
+  }
+}
+
+declare namespace svelteHTML {
+  interface HTMLAttributes<T> {
+    "on:swipe"?: (event: SwipeCustomEvent) => any
   }
 }

--- a/src/util/router.ts
+++ b/src/util/router.ts
@@ -239,7 +239,7 @@ class RouterExtension {
 
   push = (config = {}) => this.go(config)
 
-  open = (config = {}) => this.go({modal: true, drawer: true, ...config})
+  open = (config = {}) => this.go({modal: true, ...config})
 
   pushModal = (config = {}) => this.go({...config, modal: true})
 

--- a/src/util/router.ts
+++ b/src/util/router.ts
@@ -139,6 +139,7 @@ export type HistoryItem = {
   path: string
   key?: string
   mini?: boolean
+  drawer?: boolean
   modal?: boolean
   virtual?: boolean
   noEscape?: boolean
@@ -238,7 +239,7 @@ class RouterExtension {
 
   push = (config = {}) => this.go(config)
 
-  open = (config = {}) => this.go({...config, modal: true})
+  open = (config = {}) => this.go({modal: true, drawer: true, ...config})
 
   pushModal = (config = {}) => this.go({...config, modal: true})
 

--- a/src/util/swipe.ts
+++ b/src/util/swipe.ts
@@ -1,0 +1,117 @@
+export type SwipeCustomEvent = {
+  isTop: boolean
+  deltaX: number
+  deltaY: number
+  startX: number
+  startY: number
+  currentX: number
+  currentY: number
+}
+
+export function swipe(
+  node: HTMLElement,
+  options: {
+    thresholdX?: number
+    thresholdY?: number
+    direction?: "left" | "right" | "top" | "bottom"
+  } = {
+    direction: "top",
+  },
+) {
+  const {direction} = options
+  let startX: number | null
+  let startY: number | null
+
+  function handleTouchStart(event: TouchEvent) {
+    const touch = event.touches[0]
+    startX = touch.clientX
+    startY = touch.clientY
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    if (!startX || !startY) return
+
+    const touch = event.touches[0]
+    const deltaX = touch.clientX - startX
+    const deltaY = touch.clientY - startY
+
+    const lateral = deltaX > 0 ? "right" : "left"
+    const vertical = deltaY > 0 ? "top" : "bottom"
+
+    const swipeX = lateral == direction
+    const swipeY = vertical == direction
+
+    if (!swipeX && !swipeY) return
+
+    // for an horizontla swipe, make sure deltaX is 2x deltaY
+    if (swipeX && Math.abs(deltaX) < Math.abs(2 * deltaY)) return
+
+    // for an vertical swipe, make sure deltaY is 2x deltaX
+    if (swipeY && Math.abs(deltaY) < Math.abs(2 * deltaX)) return
+
+    node.dispatchEvent(
+      new CustomEvent("swipe", {
+        detail: {
+          isTop: node.scrollTop == 0,
+          startX,
+          startY,
+          deltaX,
+          deltaY,
+          currentX: touch.clientX,
+          currentY: touch.clientY,
+        },
+      }),
+    )
+  }
+
+  function handleTouchEnd(event: TouchEvent) {
+    if (!startX || !startY) return
+
+    const touch = event.changedTouches[0]
+    const deltaX = touch.clientX - startX
+    const deltaY = touch.clientY - startY
+
+    const lateral = deltaX > 0 ? "right" : "left"
+    const vertical = deltaY > 0 ? "top" : "bottom"
+
+    const swipeX = lateral == direction
+    const swipeY = vertical == direction
+
+    if (swipeX && swipeY) return
+
+    // for an horizontla swipe, make sure deltaX is 2x deltaY
+    if (swipeX && Math.abs(deltaX) < Math.abs(2 * deltaY)) return
+
+    // for an vertical swipe, make sure deltaY is 2x deltaX
+    if (swipeY && Math.abs(deltaY) < Math.abs(2 * deltaX)) return
+
+    node.dispatchEvent(
+      new CustomEvent("end", {
+        detail: {
+          isTop: node.scrollTop == 0,
+          startX,
+          startY,
+          deltaX,
+          deltaY,
+          currentX: touch.clientX,
+          currentY: touch.clientY,
+        },
+      }),
+    )
+
+    startX = null
+    startY = null
+  }
+
+  node.addEventListener("touchstart", handleTouchStart)
+  node.addEventListener("touchmove", handleTouchMove)
+  node.addEventListener("touchend", handleTouchEnd)
+
+  return {
+    destroy() {
+      node.removeEventListener("touchstart", handleTouchStart)
+      node.removeEventListener("touchmove", handleTouchMove)
+      node.removeEventListener("touchend", handleTouchEnd)
+    },
+  }
+}


### PR DESCRIPTION
Modal Drawer is now the default except for HUD, profiles and feed Edit

The side drawer has a max-width-md applied, opens from the left, the sidebar is still visible and accessible
<img width="1728" alt="Screenshot 2024-11-28 at 17 45 11" src="https://github.com/user-attachments/assets/4c66f630-4296-4422-85b5-e86853d083c5">

When another drawer opens it fully covers the first one
<img width="1728" alt="Screenshot 2024-11-28 at 17 45 21" src="https://github.com/user-attachments/assets/e9db05ff-e0bf-40d5-98b8-4f9f2db659e6">

When opening a profile page, we still have the former modal, but the side menu is still visible, I thought it was ok, but I can put it in the background if needed
<img width="1728" alt="Screenshot 2024-11-28 at 17 46 03" src="https://github.com/user-attachments/assets/48b1b954-9d48-4d71-b414-b6ce2570ad0c">


On mobile the modal still open from the bottom, I can open it from the side if needed, it is now dismissible with a swap.

https://github.com/user-attachments/assets/579e199a-f005-4927-8c40-80a1d3eef66a

