### PR TITLE
Trying to modify Code extension from mark to node

### DIFF
--- a/src/app/editor/Code.ts
+++ b/src/app/editor/Code.ts
@@ -1,0 +1,87 @@
+import {inputRegex, pasteRegex, type CodeOptions} from "@tiptap/extension-code"
+import {
+  Mark,
+  markInputRule,
+  mergeAttributes,
+  Node,
+  nodeInputRule,
+  nodePasteRule,
+  textblockTypeInputRule,
+  textInputRule,
+} from "@tiptap/core"
+
+export const Code = Node.create<CodeOptions>({
+  name: "code",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    }
+  },
+
+  excludes: "_",
+
+  code: true,
+
+  content: "text*",
+
+  marks: "",
+
+  exitable: true,
+
+  parseHTML() {
+    return [{tag: "code"}]
+  },
+
+  renderHTML({HTMLAttributes, node}) {
+    console.log("renderHTML", node.textContent)
+    return ["code", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), node.textContent]
+  },
+
+  addCommands() {
+    return {
+      setCode:
+        () =>
+        ({commands}) => {
+          return commands.setMark(this.name)
+        },
+      toggleCode:
+        () =>
+        ({commands}) => {
+          return commands.toggleMark(this.name)
+        },
+      unsetCode:
+        () =>
+        ({commands}) => {
+          return commands.unsetMark(this.name)
+        },
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-e": () => this.editor.commands.toggleCode(),
+    }
+  },
+
+  addInputRules() {
+    return [
+      textblockTypeInputRule({
+        find: inputRegex,
+        type: this.type,
+        getAttributes: match => {
+          return {content: match[1]} // Capture content inside backticks
+        },
+      }),
+    ]
+  },
+
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: pasteRegex,
+        type: this.type,
+      }),
+    ]
+  },
+})

--- a/src/app/editor/index.ts
+++ b/src/app/editor/index.ts
@@ -76,7 +76,6 @@ export const getEditorOptions = ({
   extensions: [
     Code.extend({
       renderText(props) {
-        console.log("to text")
         // Wrap the text with backticks for the Code mark
         return `\`${props.node.textContent}\``
       },

--- a/src/app/editor/index.ts
+++ b/src/app/editor/index.ts
@@ -1,6 +1,5 @@
 import {nprofileEncode} from "nostr-tools/nip19"
 import {SvelteNodeViewRenderer} from "svelte-tiptap"
-import Code from "@tiptap/extension-code"
 import CodeBlock from "@tiptap/extension-code-block"
 import Document from "@tiptap/extension-document"
 import Dropcursor from "@tiptap/extension-dropcursor"
@@ -22,7 +21,7 @@ import {ctx} from "@welshman/lib"
 import type {StampedEvent} from "@welshman/util"
 import {toNostrURI} from "@welshman/util"
 import {signer, profileSearch, RelayMode} from "@welshman/app"
-import {createSuggestions} from "./Suggestions"
+import {createSuggestions} from "src/app/editor/Suggestions"
 import EditMention from "src/app/editor/EditMention.svelte"
 import EditEvent from "src/app/editor/EditEvent.svelte"
 import EditBolt11 from "src/app/editor/EditBolt11.svelte"
@@ -34,6 +33,7 @@ import {WordCount} from "src/app/editor/wordcounts"
 import {FileUploadExtension} from "src/app/editor/FileUpload"
 import {getSetting} from "src/engine"
 import {Hashtag} from "src/app/editor/Hashtag"
+import {Code} from "./Code"
 
 export {createSuggestions, EditMention, EditEvent, EditBolt11, EditMedia, Suggestions}
 export * from "./util"
@@ -74,8 +74,18 @@ export const getEditorOptions = ({
   element,
   content,
   extensions: [
-    Code,
-    CodeBlock,
+    Code.extend({
+      renderText(props) {
+        console.log("to text")
+        // Wrap the text with backticks for the Code mark
+        return `\`${props.node.textContent}\``
+      },
+    }),
+    CodeBlock.extend({
+      renderText(props) {
+        return `\n\`\`\`\n${props.node.textContent}\n \`\`\`\n`
+      },
+    }),
     Document,
     Dropcursor,
     Gapcursor,

--- a/src/app/views/NoteCreate.svelte
+++ b/src/app/views/NoteCreate.svelte
@@ -63,61 +63,63 @@
 
     const content = editor.getText({blockSeparator: "\n"}).trim()
 
-    if (!content) return showWarning("Please provide a description.")
+    console.log(content)
 
-    if (!skipNsecWarning && content.match(/\bnsec1.+/)) return nsecWarning.set(true)
+    // if (!content) return showWarning("Please provide a description.")
 
-    const tags = [...tagsFromContent(content), ...getClientTags(), ...editor.commands.getMetaTags()]
+    // if (!skipNsecWarning && content.match(/\bnsec1.+/)) return nsecWarning.set(true)
 
-    if (options.warning) {
-      tags.push(["content-warning", options.warning])
-    }
+    // const tags = [...tagsFromContent(content), ...getClientTags(), ...editor.commands.getMetaTags()]
 
-    if (quote) {
-      tags.push(tagPubkey(quote.pubkey))
-    }
+    // if (options.warning) {
+    //   tags.push(["content-warning", options.warning])
+    // }
 
-    const template = createEvent(1, {content, tags})
-    const signedTemplate = await sign(template, options)
+    // if (quote) {
+    //   tags.push(tagPubkey(quote.pubkey))
+    // }
 
-    signaturePending = false
+    // const template = createEvent(1, {content, tags})
+    // const signedTemplate = await sign(template, options)
 
-    drafts.set("notecreate", editor.getHTML())
+    // signaturePending = false
 
-    router.clearModals()
+    // drafts.set("notecreate", editor.getHTML())
 
-    const thunk = publish({
-      event: signedTemplate,
-      relays: ctx.app.router.PublishEvent(signedTemplate).getUrls(),
-      delay: $userSettings.send_delay,
-    })
+    // router.clearModals()
 
-    thunk.result.finally(() => {
-      charCount.set(0)
-      wordCount.set(0)
-      drafts.delete("notecreate")
-    })
+    // const thunk = publish({
+    //   event: signedTemplate,
+    //   relays: ctx.app.router.PublishEvent(signedTemplate).getUrls(),
+    //   delay: $userSettings.send_delay,
+    // })
 
-    if ($userSettings.send_delay > 0) {
-      showToast({
-        id: "send-delay",
-        type: "delay",
-        timeout: $userSettings.send_delay / 1000,
-        onCancel: () => {
-          thunk.controller.abort()
-          router.at("notes/create").open()
-        },
-      })
-    }
+    // thunk.result.finally(() => {
+    //   charCount.set(0)
+    //   wordCount.set(0)
+    //   drafts.delete("notecreate")
+    // })
 
-    thunk.status.subscribe(status => {
-      if (
-        Object.values(status).length === thunk.request.relays.length &&
-        Object.values(status).every(s => s.status === PublishStatus.Pending)
-      ) {
-        showPublishInfo(thunk)
-      }
-    })
+    // if ($userSettings.send_delay > 0) {
+    //   showToast({
+    //     id: "send-delay",
+    //     type: "delay",
+    //     timeout: $userSettings.send_delay / 1000,
+    //     onCancel: () => {
+    //       thunk.controller.abort()
+    //       router.at("notes/create").open()
+    //     },
+    //   })
+    // }
+
+    // thunk.status.subscribe(status => {
+    //   if (
+    //     Object.values(status).length === thunk.request.relays.length &&
+    //     Object.values(status).every(s => s.status === PublishStatus.Pending)
+    //   ) {
+    //     showPublishInfo(thunk)
+    //   }
+    // })
   }
 
   const togglePreview = () => {


### PR DESCRIPTION
#510

CodeBlock is now parsed correctly when rendering to text.

Code on the other hand is almost impossible to correctly transform from Mark (that does not parse to text via renderText()) to a Node (that does parse to text via renderText())

It's frustrating to not be able to do such minor changes easily, leaving the code here if you want to have a look, I'm close but there is a tons of edge case still