### PR TITLE
accomodate long url in hud console

### DIFF
--- a/src/partials/ThunkNotice.svelte
+++ b/src/partials/ThunkNotice.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import cx from "classnames"
   import {formatTimestamp} from "@welshman/app"
   import {messageAndColorFromStatus, type PublishNotice} from "src/domain/connection"
 
@@ -7,9 +8,11 @@
   const {color} = messageAndColorFromStatus(notice.status)
 </script>
 
-<div class="flex gap-2 p-2">
+<div class="flex flex-wrap gap-2 p-2">
   <span class="shrink-0 text-neutral-400">{formatTimestamp(notice.created_at)}</span>
-  <strong class={color}>to {notice.url}:</strong>
+  <strong
+    class={cx(color, "max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-success")}
+    >to {notice.url}</strong>
   <span class="shrink-0">[Kind {notice.eventKind}]</span>
-  <span class="">{notice.message}</span>
+  <span>{notice.message}</span>
 </div>


### PR DESCRIPTION
Very long url will go to the next line in the console, if the url is larger than the container it will result in an ellipsis

<img width="663" alt="Screenshot 2025-01-08 at 17 17 35" src="https://github.com/user-attachments/assets/da7be6a8-6d4f-43be-9672-e0402661de31" />

#517 