### PR TITLE
Checkout all kind rendering

### DIFF
--- a/src/app/shared/ListCard.svelte
+++ b/src/app/shared/ListCard.svelte
@@ -3,11 +3,10 @@
   import {first} from "@welshman/lib"
   import {getTags, toNostrURI, Address} from "@welshman/util"
   import {defaultTagFeedMappings} from "@welshman/feeds"
-  import {repository} from "@welshman/app"
+  import {formatTimestamp, repository} from "@welshman/app"
   import {slide} from "src/util/transition"
   import {boolCtrl} from "src/partials/utils"
   import FlexColumn from "src/partials/FlexColumn.svelte"
-  import Card from "src/partials/Card.svelte"
   import Chip from "src/partials/Chip.svelte"
   import Anchor from "src/partials/Anchor.svelte"
   import CopyValueSimple from "src/partials/CopyValueSimple.svelte"
@@ -34,13 +33,16 @@
   }
 </script>
 
-<Card class="flex gap-3">
+<div class="flex justify-end text-xs">
+  {formatTimestamp(event.created_at)}
+</div>
+<div class="flex gap-3">
   <div class="mt-[6px]">
     <i class="fa fa-list fa-2xl" />
   </div>
   <FlexColumn small>
-    <div class="flex justify-between">
-      <span class="flex items-start gap-3">
+    <div class="flex items-center justify-between">
+      <span class="flex items-center gap-3">
         <div>
           <span
             class="staatliches text-xl"
@@ -89,4 +91,4 @@
         )}</pre>
     {/if}
   </FlexColumn>
-</Card>
+</div>

--- a/src/app/shared/Note.svelte
+++ b/src/app/shared/Note.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import {ctx} from "@welshman/lib"
-  import {getIdOrAddress} from "@welshman/util"
   import type {TrustedEvent} from "@welshman/util"
-  import Anchor from "src/partials/Anchor.svelte"
-  import Card from "src/partials/Card.svelte"
-  import {getSetting, isEventMuted} from "src/engine"
-  import {router} from "src/app/util"
+  import {getIdOrAddress} from "@welshman/util"
   import NoteActions from "src/app/shared/NoteActions.svelte"
   import NoteContent from "src/app/shared/NoteContent.svelte"
   import NoteHeader from "src/app/shared/NoteHeader.svelte"
   import NoteReply from "src/app/shared/NoteReply.svelte"
+  import Anchor from "src/partials/Anchor.svelte"
+  import Card from "src/partials/Card.svelte"
+  import {router} from "src/app/util"
+  import {HEADERLESS_KIND} from "src/domain"
+  import {getSetting, isEventMuted} from "src/engine"
 
   export let note: TrustedEvent
   export let depth = 0
@@ -36,7 +37,7 @@
 
 <div class="group relative">
   <Card stopPropagation class="relative" on:click={onClick} {interactive}>
-    {#if note.kind !== 31890}
+    {#if !HEADERLESS_KIND.includes(note.kind)}
       <NoteHeader event={note} {showParent} />
     {/if}
     {#if hidden && !showHidden}
@@ -49,10 +50,10 @@
           }}>Show</Anchor>
       </p>
     {:else}
-      <div class:!pl-0={note.kind === 31890} class="mt-2 pl-14">
+      <div class:!pl-0={HEADERLESS_KIND.includes(note.kind)} class="mt-2 pl-14">
         <NoteContent {note} {depth} {showEntire} {showMedia} />
       </div>
-      <div class:!pl-10={note.kind === 31890} class="pl-14 pt-4">
+      <div class:!pl-10={HEADERLESS_KIND.includes(note.kind)} class="pl-14 pt-4">
         <NoteActions event={note} />
       </div>
     {/if}

--- a/src/app/shared/Note.svelte
+++ b/src/app/shared/Note.svelte
@@ -9,7 +9,7 @@
   import Anchor from "src/partials/Anchor.svelte"
   import Card from "src/partials/Card.svelte"
   import {router} from "src/app/util"
-  import {HEADERLESS_KIND} from "src/domain"
+  import {headerLessKinds} from "src/util/nostr"
   import {getSetting, isEventMuted} from "src/engine"
 
   export let note: TrustedEvent
@@ -37,7 +37,7 @@
 
 <div class="group relative">
   <Card stopPropagation class="relative" on:click={onClick} {interactive}>
-    {#if !HEADERLESS_KIND.includes(note.kind)}
+    {#if !headerLessKinds.includes(note.kind)}
       <NoteHeader event={note} {showParent} />
     {/if}
     {#if hidden && !showHidden}
@@ -50,10 +50,10 @@
           }}>Show</Anchor>
       </p>
     {:else}
-      <div class:!pl-0={HEADERLESS_KIND.includes(note.kind)} class="mt-2 pl-14">
+      <div class:!pl-0={headerLessKinds.includes(note.kind)} class="mt-2 pl-14">
         <NoteContent {note} {depth} {showEntire} {showMedia} />
       </div>
-      <div class:!pl-10={HEADERLESS_KIND.includes(note.kind)} class="pl-14 pt-4">
+      <div class:!pl-10={headerLessKinds.includes(note.kind)} class="pl-14 pt-4">
         <NoteActions event={note} />
       </div>
     {/if}

--- a/src/app/shared/NoteContent.svelte
+++ b/src/app/shared/NoteContent.svelte
@@ -3,15 +3,14 @@
   import Anchor from "src/partials/Anchor.svelte"
   import NoteContentKind0 from "src/app/shared/NoteContentKind0.svelte"
   import NoteContentKind1 from "src/app/shared/NoteContentKind1.svelte"
-  import NoteContentKind3 from "src/app/shared/NoteContentKind3.svelte"
   import NoteContentKind40 from "src/app/shared/NoteContentKind40.svelte"
   import NoteContentKind1808 from "src/app/shared/NoteContentKind1808.svelte"
   import NoteContentKind1985 from "src/app/shared/NoteContentKind1985.svelte"
   import NoteContentKind1986 from "src/app/shared/NoteContentKind1986.svelte"
+  import NoteContentKind9041 from "src/app/shared/NoteContentKind9041.svelte"
   import NoteContentKind9735 from "src/app/shared/NoteContentKind9735.svelte"
   import NoteContentKind9802 from "src/app/shared/NoteContentKind9802.svelte"
   import NoteContentKind1063 from "src/app/shared/NoteContentKind1063.svelte"
-  import NoteContentKind10002 from "src/app/shared/NoteContentKind10002.svelte"
   import NoteContentKind30009 from "src/app/shared/NoteContentKind30009.svelte"
   import NoteContentKind30023 from "src/app/shared/NoteContentKind30023.svelte"
   import NoteContentKind30311 from "src/app/shared/NoteContentKind30311.svelte"
@@ -21,8 +20,10 @@
   import NoteContentKind31923 from "src/app/shared/NoteContentKind31923.svelte"
   import NoteContentKind32123 from "src/app/shared/NoteContentKind32123.svelte"
   import NoteContentKindList from "src/app/shared/NoteContentKindList.svelte"
+  import NoteContentKindRelay from "src/app/shared/NoteContentKindRelay.svelte"
   import {getSetting, env} from "src/engine"
   import {CUSTOM_LIST_KINDS} from "src/domain"
+  import NoteContentKind3 from "src/app/shared/NoteContentKind3.svelte"
 
   export let note
   export let depth = 0
@@ -63,8 +64,16 @@
     <NoteContentKind9802 {note} {showEntire} {showMedia} />
   {:else if note.kind === 1063}
     <NoteContentKind1063 {note} {showMedia} />
+  {:else if note.kind === 9041}
+    <NoteContentKind9041 {note} />
   {:else if note.kind === 10002}
-    <NoteContentKind10002 {note} />
+    <NoteContentKindRelay {note} kind={10002} />
+  {:else if note.kind === 10006}
+    <NoteContentKindRelay {note} kind={10006} />
+  {:else if note.kind === 10007}
+    <NoteContentKindRelay {note} kind={10007} />
+  {:else if note.kind === 10050}
+    <NoteContentKindRelay {note} kind={10050} />
   {:else if note.kind === 30009}
     <NoteContentKind30009 {note} {showMedia} />
   {:else if note.kind === 30023}

--- a/src/app/shared/NoteContentKind3.svelte
+++ b/src/app/shared/NoteContentKind3.svelte
@@ -13,12 +13,17 @@
   }
 
   let limit = showEntire ? Infinity : 5
+
+  $: isSliced = getPubkeyTagValues(note.tags).length > limit
 </script>
 
 <FlexColumn small>
-  <div style={!showEntire && "mask-image: linear-gradient(0deg, transparent 0px, black 100px)"}>
+  <div
+    style={!showEntire &&
+      isSliced &&
+      "mask-image: linear-gradient(0deg, transparent 0px, black 100px)"}>
     <div class="mb-4 border-l-2 border-solid border-neutral-600 pl-4 text-lg">
-      Updated follows list:
+      Updated follow list:
     </div>
     <div>
       {#each take(limit, getPubkeyTagValues(note.tags)) as pubkey}
@@ -28,7 +33,7 @@
       {/each}
     </div>
   </div>
-  {#if !showEntire}
+  {#if !showEntire && isSliced}
     <NoteContentEllipsis on:click={expand} />
   {/if}
 </FlexColumn>

--- a/src/app/shared/NoteContentKind9041.svelte
+++ b/src/app/shared/NoteContentKind9041.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type {TrustedEvent} from "@welshman/util"
-  import NoteContentKind1 from "./NoteContentKind1.svelte"
-  import {fromPairs} from "@welshman/lib"
+  import {ensureNumber, fromPairs} from "@welshman/lib"
   import {formatTimestamp} from "src/util/misc"
+  import NoteContentKind1 from "src/app/shared/NoteContentKind1.svelte"
 
   export let note: TrustedEvent
 
@@ -10,7 +10,10 @@
 </script>
 
 <div>
-  Raising <strong class="text-accent">{amount} Sats</strong> by {formatTimestamp(Number(closed_at))}
+  Raising <strong class="text-accent">{amount} Sats</strong>
+  {#if closed_at}
+    by {formatTimestamp(ensureNumber(closed_at))}
+  {/if}
 </div>
 {#if note.content}
   <div class="mt-2 flex space-x-2">

--- a/src/app/shared/NoteContentKind9041.svelte
+++ b/src/app/shared/NoteContentKind9041.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type {TrustedEvent} from "@welshman/util"
+  import NoteContentKind1 from "./NoteContentKind1.svelte"
+  import {fromPairs} from "@welshman/lib"
+  import {formatTimestamp} from "src/util/misc"
+
+  export let note: TrustedEvent
+
+  const {closed_at, amount} = fromPairs(note.tags)
+</script>
+
+<div>
+  Raising <strong class="text-accent">{amount} Sats</strong> by {formatTimestamp(Number(closed_at))}
+</div>
+{#if note.content}
+  <div class="mt-2 flex space-x-2">
+    <span>Goal:</span>
+    <NoteContentKind1 {note} />
+  </div>
+{/if}

--- a/src/app/shared/NoteContentKindRelay.svelte
+++ b/src/app/shared/NoteContentKindRelay.svelte
@@ -4,10 +4,19 @@
   import RelayCard from "src/app/shared/RelayCard.svelte"
 
   export let note
+  export let kind: 10002 | 10006 | 10007 | 10050 = 10002
 </script>
 
 <FlexColumn small>
-  <p>New relay selections:</p>
+  {#if kind === 10002}
+    <p>New relay selections:</p>
+  {:else if kind === 10006}
+    <p>New blocked relay selections:</p>
+  {:else if kind === 10007}
+    <p>New searched relay selections:</p>
+  {:else if kind === 10050}
+    <p>New inbox relay selections:</p>
+  {/if}
   {#each getRelayTagValues(note.tags).filter(isShareableRelayUrl) as url}
     <RelayCard {url} />
   {/each}

--- a/src/app/shared/NoteContentKindRelay.svelte
+++ b/src/app/shared/NoteContentKindRelay.svelte
@@ -2,19 +2,20 @@
   import {getRelayTagValues, isShareableRelayUrl} from "@welshman/util"
   import FlexColumn from "src/partials/FlexColumn.svelte"
   import RelayCard from "src/app/shared/RelayCard.svelte"
+  import {RELAYS, BLOCKED_RELAYS, SEARCH_RELAYS, INBOX_RELAYS} from "@welshman/util"
 
   export let note
-  export let kind: 10002 | 10006 | 10007 | 10050 = 10002
+  export let kind: 10002 | 10006 | 10007 | 10050 = RELAYS
 </script>
 
 <FlexColumn small>
-  {#if kind === 10002}
+  {#if kind === RELAYS}
     <p>New relay selections:</p>
-  {:else if kind === 10006}
+  {:else if kind === BLOCKED_RELAYS}
     <p>New blocked relay selections:</p>
-  {:else if kind === 10007}
+  {:else if kind === SEARCH_RELAYS}
     <p>New searched relay selections:</p>
-  {:else if kind === 10050}
+  {:else if kind === INBOX_RELAYS}
     <p>New inbox relay selections:</p>
   {/if}
   {#each getRelayTagValues(note.tags).filter(isShareableRelayUrl) as url}

--- a/src/domain/list.ts
+++ b/src/domain/list.ts
@@ -1,6 +1,7 @@
 import {fromPairs, randomId} from "@welshman/lib"
 import type {TrustedEvent} from "@welshman/util"
 import {
+  FEED,
   FOLLOWS,
   NAMED_PEOPLE,
   NAMED_RELAYS,
@@ -44,6 +45,27 @@ export const CUSTOM_LIST_KINDS = [
   CHANNELS,
   BLOCKED_RELAYS,
   SEARCH_RELAYS,
+  GROUPS,
+  TOPICS,
+]
+
+export const HEADERLESS_KIND = [
+  GROUPS,
+  FEED,
+  NAMED_PEOPLE,
+  NAMED_RELAYS,
+  NAMED_CURATIONS,
+  NAMED_WIKI_AUTHORS,
+  NAMED_WIKI_RELAYS,
+  NAMED_EMOJIS,
+  NAMED_TOPICS,
+  NAMED_ARTIFACTS,
+  NAMED_COMMUNITIES,
+  MUTES,
+  PINS,
+  BOOKMARKS,
+  COMMUNITIES,
+  CHANNELS,
   GROUPS,
   TOPICS,
 ]

--- a/src/domain/list.ts
+++ b/src/domain/list.ts
@@ -1,7 +1,6 @@
 import {fromPairs, randomId} from "@welshman/lib"
 import type {TrustedEvent} from "@welshman/util"
 import {
-  FEED,
   FOLLOWS,
   NAMED_PEOPLE,
   NAMED_RELAYS,
@@ -45,27 +44,6 @@ export const CUSTOM_LIST_KINDS = [
   CHANNELS,
   BLOCKED_RELAYS,
   SEARCH_RELAYS,
-  GROUPS,
-  TOPICS,
-]
-
-export const HEADERLESS_KIND = [
-  GROUPS,
-  FEED,
-  NAMED_PEOPLE,
-  NAMED_RELAYS,
-  NAMED_CURATIONS,
-  NAMED_WIKI_AUTHORS,
-  NAMED_WIKI_RELAYS,
-  NAMED_EMOJIS,
-  NAMED_TOPICS,
-  NAMED_ARTIFACTS,
-  NAMED_COMMUNITIES,
-  MUTES,
-  PINS,
-  BOOKMARKS,
-  COMMUNITIES,
-  CHANNELS,
   GROUPS,
   TOPICS,
 ]

--- a/src/util/nostr.ts
+++ b/src/util/nostr.ts
@@ -17,6 +17,22 @@ import {
   getTags,
   getTagValue,
   getTopicTagValues,
+  GROUPS,
+  FEED,
+  NAMED_PEOPLE,
+  NAMED_RELAYS,
+  NAMED_CURATIONS,
+  NAMED_WIKI_AUTHORS,
+  NAMED_WIKI_RELAYS,
+  NAMED_EMOJIS,
+  NAMED_TOPICS,
+  NAMED_ARTIFACTS,
+  NAMED_COMMUNITIES,
+  PINS,
+  BOOKMARKS,
+  COMMUNITIES,
+  CHANNELS,
+  TOPICS,
 } from "@welshman/util"
 import {identity} from "@welshman/lib"
 import type {TrustedEvent} from "@welshman/util"
@@ -44,6 +60,26 @@ export const noteKinds = [NOTE, LONG_FORM, HIGHLIGHT]
 export const reactionKinds = [REACTION, ZAP_RESPONSE] as number[]
 export const repostKinds = [REPOST, GENERIC_REPOST] as number[]
 export const metaKinds = [PROFILE, FOLLOWS, MUTES, RELAYS, INBOX_RELAYS] as number[]
+export const headerLessKinds = [
+  GROUPS,
+  FEED,
+  NAMED_PEOPLE,
+  NAMED_RELAYS,
+  NAMED_CURATIONS,
+  NAMED_WIKI_AUTHORS,
+  NAMED_WIKI_RELAYS,
+  NAMED_EMOJIS,
+  NAMED_TOPICS,
+  NAMED_ARTIFACTS,
+  NAMED_COMMUNITIES,
+  MUTES,
+  PINS,
+  BOOKMARKS,
+  COMMUNITIES,
+  CHANNELS,
+  GROUPS,
+  TOPICS,
+]
 
 export const appDataKeys = {
   USER_SETTINGS: "nostr-engine/User/settings/v1",


### PR DESCRIPTION
#507 

Some kinds were obviously missing, such as inbox, muted, or search relay, that should render like the relay list.

Most of the list kinds now render like the Feed kind (31890), they have no headers.

Zap Goal (kind 9041) was not rendered correctly.

Kind 40 notes direct us to chat.coracle.social, which no longer exist. What other client supporting NIP-28 do you suggest @staab ?

DVM responses are looking strange, could use some improvement here too.

