### PR TITLE
key PersonAbout with profile.about

### DIFF
--- a/src/app/shared/PersonAbout.svelte
+++ b/src/app/shared/PersonAbout.svelte
@@ -8,10 +8,12 @@
   const profile = deriveProfile(pubkey)
 </script>
 
-<NoteContentKind1
-  note={{content: $profile?.about || "", tags: []}}
-  class={$$props.class}
-  minLength={200}
-  maxLength={300}
-  expandable={false}
-  showEntire={!truncate} />
+{#key $profile.about}
+  <NoteContentKind1
+    note={{content: $profile.about, tags: []}}
+    class={$$props.class}
+    minLength={200}
+    maxLength={300}
+    expandable={false}
+    showEntire={!truncate} />
+{/key}


### PR DESCRIPTION
In PersonAbout, we pass a custom built note to NoteContentKind1, this note is simply muted when changing the about field on profile. So NoteContentKind1 do not re-render.

I tried a bunch of stuff to pass in a brand new note object to NoteContentKind1, nothing worked. I then just wrapped NoteContentKind1 in a #key that is the about field. Not very happy with it.

You probably have a better idea