### PR TITLE
Hide reply status when the note is being highlighted

### DIFF
--- a/src/app/shared/FeedItem.svelte
+++ b/src/app/shared/FeedItem.svelte
@@ -4,7 +4,7 @@
   import {deriveEvents} from "@welshman/store"
   import {getIdOrAddress, getReplyFilters, isChildOf, matchFilters, NOTE} from "@welshman/util"
   import {quantify} from "hurdak"
-  import {onMount} from "svelte"
+  import {onMount, setContext} from "svelte"
   import NoteMeta from "src/app/shared/NoteMeta.svelte"
   import Note from "src/app/shared/Note.svelte"
   import {ensureUnwrapped, getSetting, isEventMuted, loadEvent, sortEventsDesc} from "src/engine"
@@ -25,6 +25,8 @@
   export let showParent = true
   export let showLoading = false
   export let showMedia = getSetting("show_media")
+
+  setContext("topLevel", topLevel)
 
   let ready = false
   let event = note

--- a/src/app/shared/NoteActions.svelte
+++ b/src/app/shared/NoteActions.svelte
@@ -2,7 +2,7 @@
   import cx from "classnames"
   import {nip19} from "nostr-tools"
   import {sum, pluck} from "@welshman/lib"
-  import {onMount} from "svelte"
+  import {getContext, onMount} from "svelte"
   import {tweened} from "svelte/motion"
   import {derived} from "svelte/store"
   import {ctx, nth, nthEq, remove, last, sortBy, uniqBy, prop, identity} from "@welshman/lib"
@@ -97,6 +97,7 @@
   const seenOn = derived(trackerStore, $t =>
     remove(LOCAL_RELAY_URL, Array.from($t.getRelays(event.id))),
   )
+  const topLevel = getContext("topLevel")
 
   const setView = v => {
     view = v
@@ -282,7 +283,7 @@
   })
 </script>
 
-{#if event.created_at > $timestamp1 - 45 && event.pubkey === $pubkey}
+{#if event.created_at > $timestamp1 - 45 && event.pubkey === $pubkey && !topLevel}
   <NotePending {event} />
 {:else}
   <button

--- a/src/app/views/NoteDetail.svelte
+++ b/src/app/views/NoteDetail.svelte
@@ -3,7 +3,7 @@
   import {fly} from "src/util/transition"
   import {getIdOrAddress} from "@welshman/util"
   import Spinner from "src/partials/Spinner.svelte"
-  import Thread from "src/app/shared/FeedItem.svelte"
+  import FeedItem from "src/app/shared/FeedItem.svelte"
   import {deriveEvent} from "src/engine"
 
   export let id = null
@@ -16,7 +16,7 @@
 
 {#if $event}
   <div in:fly={{y: 20}}>
-    <Thread showLoading anchor={getIdOrAddress($event)} note={$event} {depth} {relays} />
+    <FeedItem topLevel showLoading anchor={getIdOrAddress($event)} note={$event} {depth} {relays} />
   </div>
 {:else}
   <Spinner />


### PR DESCRIPTION
#523

I am using the topLevel property on FeedItem and pass it via context all the way down to NotePending.

This allows me to hide the note status when the note is first in a displayed feed. Which happens naturally when you click on a reply or note.