### PR TITLE
Improve mute

### DIFF
--- a/src/app/shared/FeedItem.svelte
+++ b/src/app/shared/FeedItem.svelte
@@ -9,7 +9,14 @@
   import {derived} from "svelte/store"
   import NoteMeta from "src/app/shared/NoteMeta.svelte"
   import Note from "src/app/shared/Note.svelte"
-  import {ensureUnwrapped, getSetting, isEventMuted, loadEvent, sortEventsDesc} from "src/engine"
+  import {
+    ensureUnwrapped,
+    getSetting,
+    isEventMuted,
+    loadEvent,
+    sortEventsDesc,
+    userSettings,
+  } from "src/engine"
   import AltColor from "src/partials/AltColor.svelte"
   import Popover from "src/partials/Popover.svelte"
   import Spinner from "src/partials/Spinner.svelte"
@@ -205,7 +212,7 @@
               {/each}
             {/key}
           {/if}
-          {#if showHiddenReplies && mutedReplies.length > 0}
+          {#if showHiddenReplies && mutedReplies.length > 0 && $userSettings.load_muted_replies}
             <button
               class="cursor-pointer rounded-md bg-gradient-to-l from-transparent via-tinted-700 to-tinted-700 py-2 text-neutral-100 outline-0 transition-colors hover:bg-tinted-700"
               on:click={() => {

--- a/src/app/shared/FeedItem.svelte
+++ b/src/app/shared/FeedItem.svelte
@@ -212,7 +212,7 @@
               {/each}
             {/key}
           {/if}
-          {#if showHiddenReplies && mutedReplies.length > 0 && $userSettings.load_muted_replies}
+          {#if showHiddenReplies && mutedReplies.length > 0 && !$userSettings.ignore_muted_content}
             <button
               class="cursor-pointer rounded-md bg-gradient-to-l from-transparent via-tinted-700 to-tinted-700 py-2 text-neutral-100 outline-0 transition-colors hover:bg-tinted-700"
               on:click={() => {

--- a/src/app/views/UserContent.svelte
+++ b/src/app/views/UserContent.svelte
@@ -66,10 +66,7 @@
         If enabled, content flagged by the author as potentially sensitive will be hidden.
       </p>
     </FieldInline>
-    <FieldInline label="Load muted replies">
-      <Toggle bind:value={values.load_muted_replies} />
-      <p slot="info">If enabled, muted replies will be loaded.</p>
-    </FieldInline>
+
     <Field>
       <div slot="label" class="flex justify-between">
         <strong>Minimum WoT score</strong>
@@ -103,6 +100,10 @@
         termToItem={identity} />
       <p slot="info">Notes containing these words will be hidden by default.</p>
     </Field>
+    <FieldInline label="Ignore muted content">
+      <Toggle bind:value={values.ignore_muted_content} />
+      <p slot="info">If enabled, muted replies will not load.</p>
+    </FieldInline>
   </div>
   <Footer>
     <Anchor grow button tag="button" type="submit">Save</Anchor>

--- a/src/app/views/UserContent.svelte
+++ b/src/app/views/UserContent.svelte
@@ -102,7 +102,7 @@
     </Field>
     <FieldInline label="Ignore muted content">
       <Toggle bind:value={values.ignore_muted_content} />
-      <p slot="info">If enabled, muted replies will not load.</p>
+      <p slot="info">If enabled, muted replies will be ignored.</p>
     </FieldInline>
   </div>
   <Footer>

--- a/src/app/views/UserContent.svelte
+++ b/src/app/views/UserContent.svelte
@@ -66,6 +66,10 @@
         If enabled, content flagged by the author as potentially sensitive will be hidden.
       </p>
     </FieldInline>
+    <FieldInline label="Load muted replies">
+      <Toggle bind:value={values.load_muted_replies} />
+      <p slot="info">If enabled, muted replies will be loaded.</p>
+    </FieldInline>
     <Field>
       <div slot="label" class="flex justify-between">
         <strong>Minimum WoT score</strong>

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -263,7 +263,7 @@ export const defaultSettings = {
   send_delay: 0, // undo send delay in ms
   pow_difficulty: 0,
   muted_words: [],
-  load_muted_replies: true,
+  ignore_muted_content: true,
   hide_sensitive: true,
   report_analytics: true,
   min_wot_score: 0,
@@ -366,7 +366,8 @@ export const isEventMuted = withGetter(
 
         const {roots, replies} = getReplyTagValues(e.tags)
 
-        if ([e.id, e.pubkey, ...roots, ...replies].some(x => x !== $pubkey && $userMutes.has(x))) return true
+        if ([e.id, e.pubkey, ...roots, ...replies].some(x => x !== $pubkey && $userMutes.has(x)))
+          return true
 
         if (regex) {
           if (e.content?.toLowerCase().match(regex)) return true

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -366,9 +366,7 @@ export const isEventMuted = withGetter(
 
         const {roots, replies} = getReplyTagValues(e.tags)
 
-        if ([e.id, e.pubkey, ...roots, ...replies].some(x => $userMutes.has(x))) return true
-
-        if ($pubkey === e.pubkey) return false
+        if ([e.id, e.pubkey, ...roots, ...replies].some(x => x !== $pubkey && $userMutes.has(x))) return true
 
         if (regex) {
           if (e.content?.toLowerCase().match(regex)) return true

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -263,6 +263,7 @@ export const defaultSettings = {
   send_delay: 0, // undo send delay in ms
   pow_difficulty: 0,
   muted_words: [],
+  load_muted_replies: true,
   hide_sensitive: true,
   report_analytics: true,
   min_wot_score: 0,
@@ -366,6 +367,8 @@ export const isEventMuted = withGetter(
         const {roots, replies} = getReplyTagValues(e.tags)
 
         if ([e.id, e.pubkey, ...roots, ...replies].some(x => $userMutes.has(x))) return true
+
+        if ($pubkey === e.pubkey) return false
 
         if (regex) {
           if (e.content?.toLowerCase().match(regex)) return true


### PR DESCRIPTION
#498 

> Allow users to hide the "show x hidden replies" bit for muted notes

There is a new settings called "load_muted_replies", on by default, if turned off, it will hide the button

> Don't mute notes by the user's own pubkey

The only way to mute a note of your own is either to mute your own npub or that specific event id. If a word is muted and your note contain this word, it won't be hidden.

> Hide muted parents in feeds (sometimes a reply to a muted note will show up, just remove it and its parent if the parent is muted)

This one is the most challenging. It should be done in the new NoteReducer. 
The NoteReducer currently look for a parent at a depth of 2. If it turns out that the parent at the depth 3 is muted, we won't catch it.
The solution is obviously to loop until no parent is found just to check if one event in the chain is being muted, in which case all downstream event should be hidden. It might have a small performance footprint.

Awaiting your feedback on that last point to implement the needed changes