### PR TITLE
Abort signal for feeds #548

### DIFF
--- a/src/app/shared/Feed.svelte
+++ b/src/app/shared/Feed.svelte
@@ -59,7 +59,6 @@
     const definition = hasKinds
       ? feed.definition
       : makeIntersectionFeed(makeKindFeed(...noteKinds), feed.definition)
-    const signal = abortController.signal
     ctrl = createFeedController({
       feed: definition,
       forcePlatform,
@@ -101,7 +100,6 @@
   let depth = 0
   let exhausted = false
   let useWindowing = true
-  let key = Math.random()
   let ctrl: FeedController
   let events: TrustedEvent[] = []
   let buffer: TrustedEvent[] = []
@@ -138,7 +136,7 @@
 {/if}
 
 <FlexColumn bind:element>
-  {#key key}
+  {#key feed.identifier}
     <NoteReducer
       {shouldSort}
       {depth}


### PR DESCRIPTION
Use an abort signal in the feed request that will abort on each feed selection and upon page leave.

- The random key is replaced by the feed identifier.
- The key check in the onEvent callback of the feed controller is removed, as abort should prevent any more events from being streamed.
