### PR TITLE
Change /help view nosrapps url to lowercase

### DIFF
--- a/src/app/views/Help.svelte
+++ b/src/app/views/Help.svelte
@@ -45,7 +45,7 @@
         href="https://nsec.app/">nsec.app</Link
       >.
     </p>
-    <Link external class="btn btn-tall btn-low" href="https://nostrapps.com/#Signers">
+    <Link external class="btn btn-tall btn-low" href="https://nostrapps.com/#signers">
       <i class="fa fa-compass" /> Browse Signer Apps
     </Link>
   {:else if topic === "nip-17-dms"}


### PR DESCRIPTION
When going through the login flow using a remote signer, I noticed that the "Browse Signer Apps" link on the `/help` page was linking to the nostrapps site but wasn't loading any signer options. However, the same link does work on the `/login` page. Changing the `/help` page nostrapps url to all lowercase (same as on the `login` page) fixes the issue. So just a one character change for a small inconvenience...

I tested locally with chromium and firefox and it now works as expected. 