### PR TITLE
Fix send button shifting off-screen on long unbroken text (#586)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -349,6 +349,7 @@ body,
   --tiptap-object-fg: var(--neutral-800);
   --tiptap-active-bg: var(--neutral-200);
   --tiptap-active-fg: var(--neutral-800);
+    overflow-wrap: anywhere;
 }
 
 .tiptap-suggestions {


### PR DESCRIPTION
When replying and pasting a long, unbroken string (e.g. a content-addressable image URL), the send button was pushed toward the center of the composer and became unclickable.

Cause: the editor (TipTap/ProseMirror) and the send button are flex siblings. white-space: pre-wrap only breaks on spaces, so a space-less string is one unbreakable "word" with a huge min-content width. That stops min-w-0 from shrinking the editor, so it overflows and overflow-x-hidden clips the button out of reach.

Fix: add overflow-wrap: anywhere to .tiptap in src/app.css. Unlike break-word, anywhere also reduces the element's min-content width, letting the flex/grid layout collapse. Same approach already used in MediaLinkPreview.svelte.