### PR TITLE
feat: strip tracking query params from links

### DIFF
--- a/src/app/shared/NoteContentLinks.svelte
+++ b/src/app/shared/NoteContentLinks.svelte
@@ -3,11 +3,15 @@
   import MediaGrid from "src/app/shared/MediaGrid.svelte"
   import MediaLink from "src/app/shared/MediaLink.svelte"
   import {router} from "src/app/util/router"
+  import {stripTrackers} from "src/util/misc"
 
   export let urls: string[]
   export let showMedia = false
 
   const coracleRegexp = /^(https?:\/\/)?(app\.)?coracle.social/
+
+  // Avoid leaking referrer data to trackers when people follow content links
+  $: cleanUrls = urls.map(stripTrackers)
 
   const onLinkClick = (url: string, event: PointerEvent) => {
     if (event.metaKey) {
@@ -19,7 +23,7 @@
     } else if (isShareableRelayUrl(url)) {
       router.at("relays").of(url).open()
     } else if (!showMedia) {
-      router.at("media").of(url).cx({urls}).open({overlay: true})
+      router.at("media").of(url).cx({urls: cleanUrls}).open({overlay: true})
     } else {
       window.open(url, "_blank")
     }
@@ -49,9 +53,9 @@
 </script>
 
 {#if showMedia && !hidden}
-  <MediaGrid {urls} {onClose} {onLinkClick} {onImageClick} />
+  <MediaGrid urls={cleanUrls} {onClose} {onLinkClick} {onImageClick} />
 {:else}
-  {#each urls as url}
+  {#each cleanUrls as url}
     <MediaLink {url} {onClick} />
   {/each}
 {/if}

--- a/src/partials/Link.svelte
+++ b/src/partials/Link.svelte
@@ -2,6 +2,7 @@
   import {createEventDispatcher} from "svelte"
   import {randomId} from "@welshman/lib"
   import {router} from "src/app/util/router"
+  import {stripTrackers} from "src/util/misc"
 
   export let href
   export let modal = false
@@ -14,6 +15,8 @@
   export let target: string = undefined
 
   const dispatch = createEventDispatcher()
+
+  $: cleanHref = external ? stripTrackers(href) : href
 
   const onClick = (e: Event) => {
     if (stopPropagation) {
@@ -31,7 +34,7 @@
 </script>
 
 <a
-  {href}
+  {cleanHref}
   {...$$props}
   on:click={onClick}
   rel={rel === undefined ? (external ? "noopener noreferer" : "") : rel}

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -255,3 +255,51 @@ export const toSpliced = <T>(xs: T[], start: number, deleteCount: number = 0, ..
 
 export const ensureMailto = (value: string) =>
   !value.includes(":") && value.includes("@") ? "mailto:" + value : value
+
+// Tracking query params that leak user activity to ad networks.
+// Derived from https://github.com/mpchadwick/tracking-query-params-registry
+const TRACKING_PARAMS = new Set([
+  "_hsenc",
+  "_hsmi",
+  "ck_subscriber_id",
+  "dclid",
+  "fbclid",
+  "gbraid",
+  "gclid",
+  "igshid",
+  "mc_cid",
+  "mc_eid",
+  "mkt_tok",
+  "msclkid",
+  "oly_anon_id",
+  "oly_enc_id",
+  "rb_clickid",
+  "ref",
+  "ref_src",
+  "ref_url",
+  "sc_customer",
+  "sc_uid",
+  "spm",
+  "twclid",
+  "ttclid",
+  "vero_conv",
+  "vero_id",
+  "wbraid",
+  "yclid",
+])
+
+export const stripTrackers = (url: string) => {
+  try {
+    const parsed = new URL(url)
+
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(key.toLowerCase()) || key.toLowerCase().startsWith("utm_")) {
+        parsed.searchParams.delete(key)
+      }
+    }
+
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}


### PR DESCRIPTION
Closes #398

Strips common ad/tracking query params from links before they're rendered or opened:

- new `stripTrackers` util in `src/util/misc.ts`: parses the URL, deletes known tracking params (case-insensitive) plus anything prefixed `utm_`, and passes through untouched URLs / invalid strings safely.
- `NoteContentLinks`: applies it to all note content link/media URLs (covers every kind routed through it: kind 1, 20, 1111, 9802, 1063, etc.) so both the visible href and the opened URL are clean.
- `Link` component: applies it to external hrefs (profile websites and similar).

Param list is derived from the tracking-query-params registry linked in the issue. Legitimate params are preserved (`?id=42&fbclid=x` → `?id=42`); invalid URLs pass through unchanged.

Fully AI-assisted.