### PR TITLE
feat: Add OpenGraph and Twitter meta tags for sharing previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta
       http-equiv="Content-Security-Policy"
       content="script-src 'self' plausible.coracle.social 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; frame-src open.spotify.com embed.tidal.com; child-src 'none'; form-action 'none';" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Coracle - Nostr Client" />
+    <meta property="og:description" content="An open-source web client for Nostr, a protocol for decentralized social media." />
+    <meta property="og:url" content="https://coracle.social" />
+    <meta property="og:image" content="https://coracle.social/images/logo.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Coracle - Nostr Client" />
+    <meta name="twitter:description" content="An open-source web client for Nostr, a protocol for decentralized social media." />
+    <meta name="twitter:image" content="https://coracle.social/images/logo.png" />
   </head>
   <body class="w-full">
     <div id="app"></div>


### PR DESCRIPTION
## Summary
Adds OpenGraph and Twitter Card meta tags to enable rich previews when Coracle links are shared on social media.

## Changes
- OpenGraph tags: title, description, image, URL, type
- Twitter Card tags: optimized for rich preview display
- Enables preview when sharing on X/Twitter and other platforms

## Related Issue
Fixes #330